### PR TITLE
Adjusted the color of the placeholder text of the text box so that it reads more clearly in dark mode

### DIFF
--- a/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
+++ b/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
@@ -20,6 +20,7 @@ struct RmbHighlightedTextField: NSViewRepresentable {
     
     func updateNSView(_ nsView: NSTextField, context: Context) {
         nsView.attributedStringValue = getAttributedString(from: text.wrappedValue)
+        nsView.placeholderAttributedString = getPlaceholderAttributedString(from: placeholder)
     }
     
     private func getAttributedString(from text: String) -> NSMutableAttributedString {
@@ -36,6 +37,22 @@ struct RmbHighlightedTextField: NSViewRepresentable {
         attributedString.addAttribute(.foregroundColor,
                                       value: NSColor.systemBlue,
                                       range: highlightedTextRange)
+        attributedString.endEditing()
+        
+        return attributedString
+    }
+    
+    private func getPlaceholderAttributedString(from text: String) -> NSMutableAttributedString {
+        let fullRange = text.fullRange
+        
+        let attributedString = NSMutableAttributedString(string: text)
+        attributedString.beginEditing()
+        attributedString.addAttribute(.foregroundColor,
+                                       value: NSColor.systemGray.withAlphaComponent(0.5),
+                                       range: fullRange)
+        attributedString.addAttribute(.font,
+                                      value: NSFont.preferredFont(forTextStyle: .callout),
+                                      range: fullRange)
         attributedString.endEditing()
         
         return attributedString

--- a/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
+++ b/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
@@ -43,7 +43,7 @@ struct RmbHighlightedTextField: NSViewRepresentable {
     
     private func getPlaceholderAttributedString(from text: String) -> NSAttributedString {
         let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: NSColor.systemGray.withAlphaComponent(0.5),
+            .foregroundColor: NSColor.systemGray,
             .font: NSFont.preferredFont(forTextStyle: .callout)
         ]
         

--- a/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
+++ b/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
@@ -9,6 +9,7 @@ struct RmbHighlightedTextField: NSViewRepresentable {
     func makeNSView(context: Context) -> NSTextField {
         let textField = NSTextField(frame: .infinite)
         textField.delegate = context.coordinator
+        textField.placeholderAttributedString = getPlaceholderAttributedString(from: placeholder)
         textField.isBordered = false
         textField.backgroundColor = NSColor.clear
         textField.cell?.wraps = false
@@ -19,10 +20,6 @@ struct RmbHighlightedTextField: NSViewRepresentable {
     
     func updateNSView(_ nsView: NSTextField, context: Context) {
         nsView.attributedStringValue = getAttributedString(from: text.wrappedValue)
-        nsView.placeholderAttributedString = getPlaceholderAttributedString(
-            from: placeholder,
-            withScheme: context.environment.colorSchemeContrast
-        )
     }
     
     private func getAttributedString(from text: String) -> NSMutableAttributedString {
@@ -44,13 +41,9 @@ struct RmbHighlightedTextField: NSViewRepresentable {
         return attributedString
     }
     
-    private func getPlaceholderAttributedString(
-        from text: String,
-        withScheme colorScheme: ColorSchemeContrast
-    ) -> NSAttributedString {
+    private func getPlaceholderAttributedString(from text: String) -> NSAttributedString {
         let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: colorScheme == .standard ?
-            NSColor.systemGray.withAlphaComponent(0.5) : NSColor.systemGray,
+            .foregroundColor: NSColor.systemGray,
             .font: NSFont.preferredFont(forTextStyle: .callout)
         ]
         

--- a/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
+++ b/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
@@ -10,7 +10,6 @@ struct RmbHighlightedTextField: NSViewRepresentable {
         let textField = NSTextField(frame: .infinite)
         textField.delegate = context.coordinator
         textField.isBordered = false
-        textField.placeholderAttributedString = getPlaceholderAttributedString(from: placeholder)
         textField.backgroundColor = NSColor.clear
         textField.cell?.wraps = false
         textField.cell?.isScrollable = true
@@ -20,6 +19,10 @@ struct RmbHighlightedTextField: NSViewRepresentable {
     
     func updateNSView(_ nsView: NSTextField, context: Context) {
         nsView.attributedStringValue = getAttributedString(from: text.wrappedValue)
+        nsView.placeholderAttributedString = getPlaceholderAttributedString(
+            from: placeholder,
+            withScheme: context.environment.colorSchemeContrast
+        )
     }
     
     private func getAttributedString(from text: String) -> NSMutableAttributedString {
@@ -41,9 +44,12 @@ struct RmbHighlightedTextField: NSViewRepresentable {
         return attributedString
     }
     
-    private func getPlaceholderAttributedString(from text: String) -> NSAttributedString {
+    private func getPlaceholderAttributedString(
+        from text: String,
+        withScheme colorScheme: ColorSchemeContrast
+    ) -> NSAttributedString {
         let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: NSColor.systemGray,
+            .foregroundColor: colorScheme == .standard ? NSColor.systemGray.withAlphaComponent(0.5) : NSColor.systemGray,
             .font: NSFont.preferredFont(forTextStyle: .callout)
         ]
         

--- a/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
+++ b/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
@@ -49,7 +49,8 @@ struct RmbHighlightedTextField: NSViewRepresentable {
         withScheme colorScheme: ColorSchemeContrast
     ) -> NSAttributedString {
         let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: colorScheme == .standard ? NSColor.systemGray.withAlphaComponent(0.5) : NSColor.systemGray,
+            .foregroundColor: colorScheme == .standard ?
+            NSColor.systemGray.withAlphaComponent(0.5) : NSColor.systemGray,
             .font: NSFont.preferredFont(forTextStyle: .callout)
         ]
         

--- a/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
+++ b/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
@@ -41,20 +41,13 @@ struct RmbHighlightedTextField: NSViewRepresentable {
         return attributedString
     }
     
-    private func getPlaceholderAttributedString(from text: String) -> NSMutableAttributedString {
-        let fullRange = text.fullRange
+    private func getPlaceholderAttributedString(from text: String) -> NSAttributedString {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor.systemGray.withAlphaComponent(0.5),
+            .font: NSFont.preferredFont(forTextStyle: .callout)
+        ]
         
-        let attributedString = NSMutableAttributedString(string: text)
-        attributedString.beginEditing()
-        attributedString.addAttribute(.foregroundColor,
-                                       value: NSColor.systemGray.withAlphaComponent(0.5),
-                                       range: fullRange)
-        attributedString.addAttribute(.font,
-                                      value: NSFont.preferredFont(forTextStyle: .callout),
-                                      range: fullRange)
-        attributedString.endEditing()
-        
-        return attributedString
+        return NSAttributedString(string: text, attributes: attributes)
     }
     
     func makeCoordinator() -> Coordinator {

--- a/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
+++ b/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
@@ -10,6 +10,7 @@ struct RmbHighlightedTextField: NSViewRepresentable {
         let textField = NSTextField(frame: .infinite)
         textField.delegate = context.coordinator
         textField.isBordered = false
+        textField.placeholderAttributedString = getPlaceholderAttributedString(from: placeholder)
         textField.backgroundColor = NSColor.clear
         textField.cell?.wraps = false
         textField.cell?.isScrollable = true
@@ -19,7 +20,6 @@ struct RmbHighlightedTextField: NSViewRepresentable {
     
     func updateNSView(_ nsView: NSTextField, context: Context) {
         nsView.attributedStringValue = getAttributedString(from: text.wrappedValue)
-        nsView.placeholderAttributedString = getPlaceholderAttributedString(from: placeholder)
     }
     
     private func getAttributedString(from text: String) -> NSMutableAttributedString {

--- a/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
+++ b/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
@@ -9,7 +9,6 @@ struct RmbHighlightedTextField: NSViewRepresentable {
     func makeNSView(context: Context) -> NSTextField {
         let textField = NSTextField(frame: .infinite)
         textField.delegate = context.coordinator
-        textField.placeholderString = placeholder
         textField.isBordered = false
         textField.backgroundColor = NSColor.clear
         textField.cell?.wraps = false


### PR DESCRIPTION
New light mode placeholder text (no difference compared to old light mode placeholder text):
<img width="335" alt="Screenshot 2023-05-23 at 10 47 32 AM" src="https://github.com/DamascenoRafael/reminders-menubar/assets/60021592/4d84d91c-debb-4a7e-96b4-e0e89310fa68">
New dark mode placeholder text (fixed readability): 
<img width="332" alt="Screenshot 2023-05-23 at 10 48 36 AM" src="https://github.com/DamascenoRafael/reminders-menubar/assets/60021592/5b787d00-06d1-4c4d-aabb-0a24b1893236">
Old dark mode placeholder text (with readability issues):
<img width="283" alt="Screenshot 2023-05-23 at 10 49 07 AM" src="https://github.com/DamascenoRafael/reminders-menubar/assets/60021592/684326a2-3eb1-474b-a82a-fb91a092b83a">