### PR TITLE
Fix #173: en_GB incorrectly resets to en_US for date pickers

### DIFF
--- a/reminders-menubar/Resources/remindersLocalized.swift
+++ b/reminders-menubar/Resources/remindersLocalized.swift
@@ -105,7 +105,8 @@ func rmbCurrentLocale() -> Locale {
     if let preferredLanguage = UserPreferences.shared.preferredLanguage {
         currentLocale = Locale(identifier: preferredLanguage)
     }
-    if Bundle.main.path(forResource: currentLocale.identifier, ofType: "lproj") == nil {
+    let Has = Bundle.main.localizations.contains
+    if !(Has(currentLocale.identifier) || Has(currentLocale.languageCode ?? "")) {
         // Return the default locale if translation to system language does not exist
         return Locale(identifier: "en_US")
     }

--- a/reminders-menubar/Resources/remindersLocalized.swift
+++ b/reminders-menubar/Resources/remindersLocalized.swift
@@ -105,8 +105,8 @@ func rmbCurrentLocale() -> Locale {
     if let preferredLanguage = UserPreferences.shared.preferredLanguage {
         currentLocale = Locale(identifier: preferredLanguage)
     }
-    let Has = Bundle.main.localizations.contains
-    if !(Has(currentLocale.identifier) || Has(currentLocale.languageCode ?? "")) {
+    let exists = Bundle.main.localizations.contains
+    if !(exists(currentLocale.identifier) || exists(currentLocale.languageCode ?? "")) {
         // Return the default locale if translation to system language does not exist
         return Locale(identifier: "en_US")
     }

--- a/reminders-menubar/Resources/remindersLocalized.swift
+++ b/reminders-menubar/Resources/remindersLocalized.swift
@@ -105,11 +105,6 @@ func rmbCurrentLocale() -> Locale {
     if let preferredLanguage = UserPreferences.shared.preferredLanguage {
         currentLocale = Locale(identifier: preferredLanguage)
     }
-    let exists = Bundle.main.localizations.contains
-    if !(exists(currentLocale.identifier) || exists(currentLocale.languageCode ?? "")) {
-        // Return the default locale if translation to system language does not exist
-        return Locale(identifier: "en_US")
-    }
     
     return currentLocale
 }


### PR DESCRIPTION
Reliably fixes #173 on my machine, and has no obvious breakage even when e.g. the language is set to `fr_CA`.

Changes 'does language exist' check to use `Bundle.main.localizations` rather than `.lproj` pathing on both the locale code and the language code before defaulting to `en_US`.