### PR TITLE
Use swift concurrency to remove hang

### DIFF
--- a/reminders-menubar/AppDelegate.swift
+++ b/reminders-menubar/AppDelegate.swift
@@ -17,6 +17,7 @@ struct RemindersMenuBar: App {
     }
 }
 
+@MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     static private(set) var shared: AppDelegate!
     
@@ -27,6 +28,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     let popover = NSPopover()
     lazy var statusBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    @MainActor
     var contentViewController: NSViewController {
         let contentView = ContentView()
         let remindersData = RemindersData()

--- a/reminders-menubar/AppDelegate.swift
+++ b/reminders-menubar/AppDelegate.swift
@@ -28,7 +28,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     let popover = NSPopover()
     lazy var statusBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-    @MainActor
+    
     var contentViewController: NSViewController {
         let contentView = ContentView()
         let remindersData = RemindersData()

--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -2,53 +2,64 @@ import SwiftUI
 import Combine
 import EventKit
 
+@MainActor
 class RemindersData: ObservableObject {
     private let userPreferences = UserPreferences.shared
-    
+
     private var cancellationTokens: [AnyCancellable] = []
-    
+
     init() {
         addObservers()
-        update()
+        Task {
+            await update()
+        }
     }
-    
-    private func addObservers() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(update),
-                                               name: .EKEventStoreChanged,
-                                               object: nil)
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(update),
-                                               name: .NSCalendarDayChanged,
-                                               object: nil)
-        
-        cancellationTokens.append(
-            userPreferences.$menuBarCounterType.dropFirst().sink { [weak self] menuBarCounterType in
-                let count = self?.getMenuBarCount(menuBarCounterType) ?? -1
-                self?.updateMenuBarCount(with: count)
+    private func addObservers() {
+        NotificationCenter.default.publisher(for: .EKEventStoreChanged)
+            .sink { [weak self] _ in
+                self?.update()
             }
-        )
-        
-        cancellationTokens.append(
-            userPreferences.$upcomingRemindersInterval.dropFirst().sink { [weak self] upcomingRemindersInterval in
-                self?.upcomingReminders = RemindersService.shared.getUpcomingReminders(upcomingRemindersInterval)
+            .store(in: &cancellationTokens)
+
+        NotificationCenter.default.publisher(for: .NSCalendarDayChanged)
+            .sink { [weak self] _ in
+                self?.update()
             }
-        )
-        
-        cancellationTokens.append(
-            $calendarIdentifiersFilter.dropFirst().sink { [weak self] calendarIdentifiersFilter in
-                self?.filteredReminderLists = RemindersService.shared.getReminders(of: calendarIdentifiersFilter)
+            .store(in: &cancellationTokens)
+
+        userPreferences.$menuBarCounterType.dropFirst().sink { [weak self] menuBarCounterType in
+            guard let self else { return }
+            Task {
+                let count = await self.getMenuBarCount(menuBarCounterType)
+                self.updateMenuBarCount(with: count)
             }
-        )
+        }
+        .store(in: &cancellationTokens)
+
+        userPreferences.$upcomingRemindersInterval.dropFirst().sink { [weak self] upcomingRemindersInterval in
+            guard let self else { return }
+            Task {
+                self.upcomingReminders = await RemindersService.shared.getUpcomingReminders(upcomingRemindersInterval)
+            }
+        }.store(in: &cancellationTokens)
+
+        $calendarIdentifiersFilter.dropFirst().sink { [weak self] calendarIdentifiersFilter in
+            guard let self else { return }
+            Task {
+                self.filteredReminderLists = await RemindersService.shared.getReminders(of: calendarIdentifiersFilter)
+            }
+
+        }
+        .store(in: &cancellationTokens)
     }
-    
+
     @Published var calendars: [EKCalendar] = []
-    
+
     @Published var upcomingReminders: [ReminderItem] = []
-    
+
     @Published var filteredReminderLists: [ReminderList] = []
-    
+
     @Published var calendarIdentifiersFilter: [String] = {
         guard let identifiers = UserPreferences.shared.preferredCalendarIdentifiersFilter else {
             // NOTE: On first use it will load all reminder lists.
@@ -56,24 +67,24 @@ class RemindersData: ObservableObject {
             let allIdentifiers = calendars.map({ $0.calendarIdentifier })
             return allIdentifiers
         }
-        
+
         return identifiers
     }() {
         didSet {
             UserPreferences.shared.preferredCalendarIdentifiersFilter = calendarIdentifiersFilter
         }
     }
-    
+
     @Published var calendarForSaving: EKCalendar? = {
         guard RemindersService.shared.authorizationStatus() == .authorized else {
             return nil
         }
-        
+
         guard let identifier = UserPreferences.shared.preferredCalendarIdentifierForSaving,
               let calendar = RemindersService.shared.getCalendar(withIdentifier: identifier) else {
             return RemindersService.shared.getDefaultCalendar()
         }
-        
+
         return calendar
     }() {
         didSet {
@@ -81,42 +92,44 @@ class RemindersData: ObservableObject {
             UserPreferences.shared.preferredCalendarIdentifierForSaving = identifier
         }
     }
-    
-    @objc func update() {
+
+    func update() {
+        Task { [weak self] in
+            await self?.update()
+        }
+    }
+
+    func update() async {
         let calendars = RemindersService.shared.getCalendars()
-        
+
         let calendarsSet = Set(calendars.map({ $0.calendarIdentifier }))
         let calendarIdentifiersFilter = self.calendarIdentifiersFilter.filter({
             // NOTE: Checking if calendar in filter still exist
             calendarsSet.contains($0)
         })
-        
+
         let upcomingRemindersInterval = self.userPreferences.upcomingRemindersInterval
-        let upcomingReminders = RemindersService.shared.getUpcomingReminders(upcomingRemindersInterval)
-        
-        let menuBarCount = getMenuBarCount(self.userPreferences.menuBarCounterType)
-        
-        // TODO: Prefer receive(on:options:) over explicit use of dispatch queues when performing work in subscribers.
-        // https://developer.apple.com/documentation/combine/fail/receive(on:options:)
-        DispatchQueue.main.async {
-            self.calendars = calendars
-            self.calendarIdentifiersFilter = calendarIdentifiersFilter
-            self.upcomingReminders = upcomingReminders
-            self.updateMenuBarCount(with: menuBarCount)
-        }
+        let upcomingReminders = await RemindersService.shared.getUpcomingReminders(upcomingRemindersInterval)
+
+        let menuBarCount = await getMenuBarCount(self.userPreferences.menuBarCounterType)
+
+        self.calendars = calendars
+        self.calendarIdentifiersFilter = calendarIdentifiersFilter
+        self.upcomingReminders = upcomingReminders
+        self.updateMenuBarCount(with: menuBarCount)
     }
-    
-    private func getMenuBarCount(_ menuBarCounterType: RmbMenuBarCounterType) -> Int {
+
+    private func getMenuBarCount(_ menuBarCounterType: RmbMenuBarCounterType) async -> Int {
         switch menuBarCounterType {
         case .today:
-            return RemindersService.shared.getUpcomingReminders(.today).count
+            return await RemindersService.shared.getUpcomingReminders(.today).count
         case .allReminders:
-            return RemindersService.shared.getAllRemindersCount()
+            return await RemindersService.shared.getAllRemindersCount()
         case .disabled:
             return -1
         }
     }
-    
+
     private func updateMenuBarCount(with count: Int) {
         AppDelegate.shared.updateMenuBarTodayCount(to: count)
     }

--- a/reminders-menubar/Views/ReminderItemView.swift
+++ b/reminders-menubar/Views/ReminderItemView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import EventKit
 
+@MainActor
 struct ReminderItemView: View {
     @EnvironmentObject var remindersData: RemindersData
     
@@ -158,6 +159,7 @@ struct ReminderItemView: View {
     }
 }
 
+@MainActor
 struct ChangePriorityOptionMenu: View {
     var reminder: EKReminder
     

--- a/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
+++ b/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
@@ -48,7 +48,9 @@ struct SettingsBarGearMenu: View {
                 Divider()
                 
                 Button(action: {
-                    remindersData.update()
+                    Task {
+                        await remindersData.update()
+                    }
                 }) {
                     Text(rmbLocalized(.reloadRemindersDataButton))
                 }


### PR DESCRIPTION
The previous `fetchRemindersSynchronously` blocks the main thread whenever you update the data store, resulting in an unpleasant behavior. This PR uses async/await syntax to guarantee forward progress.