### PR TITLE
Add 'due' option for menubar counter & upcoming reminders

### DIFF
--- a/reminders-menubar/Models/ReminderInterval.swift
+++ b/reminders-menubar/Models/ReminderInterval.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum ReminderInterval: String, Codable, CaseIterable {
+    case due
     case today
     case week
     case month
@@ -8,6 +9,8 @@ enum ReminderInterval: String, Codable, CaseIterable {
     
     var title: String {
         switch self {
+        case .due:
+            return rmbLocalized(.upcomingRemindersDueTitle)
         case .today:
             return rmbLocalized(.upcomingRemindersTodayTitle)
         case .week:
@@ -21,6 +24,8 @@ enum ReminderInterval: String, Codable, CaseIterable {
     
     var endingDate: Date? {
         switch self {
+        case .due:
+            return Date()
         case .today:
             return Calendar.current.endOfDay(for: Date())
         case .week:

--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -123,6 +123,8 @@ class RemindersData: ObservableObject {
 
     private func getMenuBarCount(_ menuBarCounterType: RmbMenuBarCounterType) async -> Int {
         switch menuBarCounterType {
+        case .due:
+            return await RemindersService.shared.getUpcomingReminders(.due).count
         case .today:
             return await RemindersService.shared.getUpcomingReminders(.today).count
         case .allReminders:

--- a/reminders-menubar/Models/RmbMenuBarCounterType.swift
+++ b/reminders-menubar/Models/RmbMenuBarCounterType.swift
@@ -1,6 +1,19 @@
-enum RmbMenuBarCounterType: String, Codable {
+enum RmbMenuBarCounterType: String, Codable, CaseIterable {
     case due
     case today
     case allReminders
     case disabled
+    
+    var title: String {
+        switch self {
+        case .due:
+            return rmbLocalized(.showMenuBarDueCountOptionButton)
+        case .today:
+            return rmbLocalized(.showMenuBarTodayCountOptionButton)
+        case .allReminders:
+            return rmbLocalized(.showMenuBarAllRemindersCountOptionButton)
+        case .disabled:
+            return rmbLocalized(.showMenuBarNoCountOptionButton)
+        }
+    }
 }

--- a/reminders-menubar/Models/RmbMenuBarCounterType.swift
+++ b/reminders-menubar/Models/RmbMenuBarCounterType.swift
@@ -1,4 +1,5 @@
 enum RmbMenuBarCounterType: String, Codable {
+    case due
     case today
     case allReminders
     case disabled

--- a/reminders-menubar/Resources/de.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/de.lproj/Localizable.strings
@@ -41,9 +41,10 @@
 "appAppearanceColorDarkModeOptionButton" = "Dark mode"; // TODO: Translate
 "menuBarIconSettingsMenu" = "Menüleiste"; // TODO: Adjust to match "Menu bar icon"
 "menuBarCounterSettingsMenu" = "Menu bar counter"; // TODO: Translate
+"showMenuBarDueCountOptionButton" = "Fällige Anzahl anzeigen";
 "showMenuBarTodayCountOptionButton" = "Heutige Anzahl anzeigen";
-"showMenuBarAllRemindersCountOptionButton" = "Show all reminders count"; // TODO: Translate
-"showMenuBarNoCountOptionButton" = "Don't show count"; // TODO: Translate
+"showMenuBarAllRemindersCountOptionButton" = "Anzahl aller Erinnerungen anzeigen";
+"showMenuBarNoCountOptionButton" = "Anzahl nicht anzeigen";
 "keyboardShortcutOptionButton" = "Tastaturkürzel";
 "reloadRemindersDataButton" = "Erinnerungen aktualisieren";
 "appAboutButton" = "Über";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "Tastaturkürzel zum Öffnen der %@ aktivieren";
 "keyboardShortcutRestoreDefaultButton" = "Standard wiederherstellen";
 "upcomingRemindersIntervalSelectionHelp" = "Auswählen welcher Zeitraum für Erinnerungen angezeigt werden soll";
+"upcomingRemindersDueTitle" = "Fällig";
 "upcomingRemindersTodayTitle" = "Heute";
 "upcomingRemindersInAWeekTitle" = "In einer Woche";
 "upcomingRemindersInAMonthTitle" = "In einem Monat";

--- a/reminders-menubar/Resources/en.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/en.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "Dark mode";
 "menuBarIconSettingsMenu" = "Menu bar icon";
 "menuBarCounterSettingsMenu" = "Menu bar counter";
+"showMenuBarDueCountOptionButton" = "Show due count";
 "showMenuBarTodayCountOptionButton" = "Show today's count";
 "showMenuBarAllRemindersCountOptionButton" = "Show all reminders count";
 "showMenuBarNoCountOptionButton" = "Don't show count";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "Enable keyboard shortcut to open %@";
 "keyboardShortcutRestoreDefaultButton" = "Restore default";
 "upcomingRemindersIntervalSelectionHelp" = "Select range of upcoming reminders to be shown";
+"upcomingRemindersDueTitle" = "Due";
 "upcomingRemindersTodayTitle" = "Today";
 "upcomingRemindersInAWeekTitle" = "In a Week";
 "upcomingRemindersInAMonthTitle" = "In a Month";

--- a/reminders-menubar/Resources/es-419.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/es-419.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "Dark mode"; // TODO: Translate
 "menuBarIconSettingsMenu" = "Menu bar"; // TODO: Adjust to match "Menu bar icon"
 "menuBarCounterSettingsMenu" = "Menu bar counter"; // TODO: Translate
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "Mostrar el conteo de hoy en la barra de menú";
 "showMenuBarAllRemindersCountOptionButton" = "Show all reminders count"; // TODO: Translate
 "showMenuBarNoCountOptionButton" = "Don't show count"; // TODO: Translate
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "Habilitar atajos del teclado para abrir %@";
 "keyboardShortcutRestoreDefaultButton" = "Restaurar los ajustes predeterminados";
 "upcomingRemindersIntervalSelectionHelp" = "Seleccione el rango de los próximos recordatorios que se mostrarán";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "Hoy";
 "upcomingRemindersInAWeekTitle" = "En una semana";
 "upcomingRemindersInAMonthTitle" = "En un mes";

--- a/reminders-menubar/Resources/fr.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/fr.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "Mode sombre";
 "menuBarIconSettingsMenu" = "Icon de la barre de menu";
 "menuBarCounterSettingsMenu" = "Compteur de la barre de menu";
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "Afficher les rappels de la journée";
 "showMenuBarAllRemindersCountOptionButton" = "Afficher tous les rappels";
 "showMenuBarNoCountOptionButton" = "Ne pas afficher le compteur";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "Activer le raccourci clavier suivant pour afficher %@";
 "keyboardShortcutRestoreDefaultButton" = "Réinitialiser les réglages par défaut";
 "upcomingRemindersIntervalSelectionHelp" = "Sélectionnez l'intervalle des prochains rappels à afficher";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "Aujourd'hui";
 "upcomingRemindersInAWeekTitle" = "Dans une semaine";
 "upcomingRemindersInAMonthTitle" = "Dans un mois";

--- a/reminders-menubar/Resources/it.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/it.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "Scuro";
 "menuBarIconSettingsMenu" = "Icona barra dei menu";
 "menuBarCounterSettingsMenu" = "Contatore barra dei menu";
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "Mostra conteggio di oggi";
 "showMenuBarAllRemindersCountOptionButton" = "Mostra conteggio di tutti";
 "showMenuBarNoCountOptionButton" = "Non mostrare conteggio";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "Abilita la scorciatoia da tastiera per aprire %@";
 "keyboardShortcutRestoreDefaultButton" = "Ripristina predefinita";
 "upcomingRemindersIntervalSelectionHelp" = "Modifica l'intervallo dei prossimi promemoria da mostrare";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "Oggi";
 "upcomingRemindersInAWeekTitle" = "Tra una settimana";
 "upcomingRemindersInAMonthTitle" = "Tra un mese";

--- a/reminders-menubar/Resources/ja.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/ja.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "Dark mode"; // TODO: Translate
 "menuBarIconSettingsMenu" = "メニューバー"; // TODO: Adjust to match "Menu bar icon"
 "menuBarCounterSettingsMenu" = "Menu bar counter"; // TODO: Translate
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "今日の件数を表示";
 "showMenuBarAllRemindersCountOptionButton" = "Show all reminders count"; // TODO: Translate
 "showMenuBarNoCountOptionButton" = "Don't show count"; // TODO: Translate
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "キーボード ショートカットを有効にして%@を開く";
 "keyboardShortcutRestoreDefaultButton" = "デフォルトに戻す";
 "upcomingRemindersIntervalSelectionHelp" = "今後のリマインダーの表示範囲を設定";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "今日";
 "upcomingRemindersInAWeekTitle" = "1週間以内";
 "upcomingRemindersInAMonthTitle" = "1か月以内";

--- a/reminders-menubar/Resources/ko.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/ko.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "다크 모드";
 "menuBarIconSettingsMenu" = "메뉴 막대 아이콘";
 "menuBarCounterSettingsMenu" = "메뉴 막대 카운트";
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "오늘 마감 항목 갯수 보기";
 "showMenuBarAllRemindersCountOptionButton" = "모든 미리 알림 항목 갯수 보기";
 "showMenuBarNoCountOptionButton" = "카운트 보지 않기";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "%@ 을(를) 열기 위한 키보드 단축키 사용";
 "keyboardShortcutRestoreDefaultButton" = "기본값으로 되돌리기";
 "upcomingRemindersIntervalSelectionHelp" = "예정된 미리 알림 범위 선택";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "오늘";
 "upcomingRemindersInAWeekTitle" = "이번 주";
 "upcomingRemindersInAMonthTitle" = "이번 달";

--- a/reminders-menubar/Resources/nl.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/nl.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "Donkere weergave";
 "menuBarIconSettingsMenu" = "Menubalkpictogram";
 "menuBarCounterSettingsMenu" = "Menubalk teller";
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "Toon het aantal items van vandaag";
 "showMenuBarAllRemindersCountOptionButton" = "Laat alle herinnering aantallen zien";
 "showMenuBarNoCountOptionButton" = "Laat het aantal niet zien";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "Sneltoets inschakelen om %@ te openen";
 "keyboardShortcutRestoreDefaultButton" = "Standaardwaardes herstellen";
 "upcomingRemindersIntervalSelectionHelp" = "Selecteer een reeks aankomende herinneringen die moeten worden weergegeven";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "Vandaag";
 "upcomingRemindersInAWeekTitle" = "In een Week";
 "upcomingRemindersInAMonthTitle" = "In een Maand";

--- a/reminders-menubar/Resources/pl.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/pl.lproj/Localizable.strings
@@ -40,10 +40,11 @@
 "appAppearanceColorLightModeOptionButton" = "Jasny";
 "appAppearanceColorDarkModeOptionButton" = "Ciemny";
 "menuBarIconSettingsMenu" = "Ikona na Pasku Menu";
-"menuBarCounterSettingsMenu" = "Licznik na Pasku Menu";
-"showMenuBarTodayCountOptionButton" = "Pokaż dzisiejszy licznik";
-"showMenuBarAllRemindersCountOptionButton" = "Pokaż liczbę wszystkich przypomnień";
-"showMenuBarNoCountOptionButton" = "Nie pokazuj licznika";
+"menuBarCounterSettingsMenu" = "Pokaż liczbę na pasku";
+"showMenuBarDueCountOptionButton" = "Pokaż liczbę nadchodzących przypomnień";
+"showMenuBarTodayCountOptionButton" = "Pokaż liczbę dzisiejszych przypomnień";
+"showMenuBarAllRemindersCountOptionButton" = "Pokaż liczbę wszystkich przypomnień"; 
+"showMenuBarNoCountOptionButton" = "Nie pokazuj liczby";
 "keyboardShortcutOptionButton" = "Skrót klawiaturowy";
 "reloadRemindersDataButton" = "Odśwież dane";
 "appAboutButton" = "O Aplikacji";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "Włącz skrót klawiaturowy, aby otworzyć %@";
 "keyboardShortcutRestoreDefaultButton" = "Przywróć wartości domyślne";
 "upcomingRemindersIntervalSelectionHelp" = "Wybierz zakres nadchodzących przypomnień do wyświetlenia";
+"upcomingRemindersDueTitle" = "Nadchodzące"; // TODO: translate
 "upcomingRemindersTodayTitle" = "Dzisiaj";
 "upcomingRemindersInAWeekTitle" = "W ciągu Tygodnia";
 "upcomingRemindersInAMonthTitle" = "W ciągu Miesiąca";

--- a/reminders-menubar/Resources/pt-BR.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/pt-BR.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "Modo escuro";
 "menuBarIconSettingsMenu" = "Ícone da barra de menu";
 "menuBarCounterSettingsMenu" = "Contagem da barra de menu";
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "Mostrar contagem para hoje";
 "showMenuBarAllRemindersCountOptionButton" = "Mostrar contagem de todos os lembretes";
 "showMenuBarNoCountOptionButton" = "Não mostrar contagem";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "Habilitar atalho de teclado para abrir %@";
 "keyboardShortcutRestoreDefaultButton" = "Restaurar padrão";
 "upcomingRemindersIntervalSelectionHelp" = "Selecione o intervalo para os próximos lembretes a serem mostrados";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "Hoje";
 "upcomingRemindersInAWeekTitle" = "Em uma Semana";
 "upcomingRemindersInAMonthTitle" = "Em um Mês";

--- a/reminders-menubar/Resources/remindersLocalized.swift
+++ b/reminders-menubar/Resources/remindersLocalized.swift
@@ -44,6 +44,7 @@ enum RemindersMenuBarLocalizedKeys: String {
     case appAppearanceColorDarkModeOptionButton
     case menuBarIconSettingsMenu
     case menuBarCounterSettingsMenu
+    case showMenuBarDueCountOptionButton
     case showMenuBarTodayCountOptionButton
     case showMenuBarAllRemindersCountOptionButton
     case showMenuBarNoCountOptionButton
@@ -61,6 +62,7 @@ enum RemindersMenuBarLocalizedKeys: String {
     case keyboardShortcutEnableOpenShortcutOption
     case keyboardShortcutRestoreDefaultButton
     case upcomingRemindersIntervalSelectionHelp
+    case upcomingRemindersDueTitle
     case upcomingRemindersTodayTitle
     case upcomingRemindersInAWeekTitle
     case upcomingRemindersInAMonthTitle

--- a/reminders-menubar/Resources/sk.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/sk.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "Tmavý vzhľad";
 "menuBarIconSettingsMenu" = "Ikona v lište";
 "menuBarCounterSettingsMenu" = "Počítadlo v lište";
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "Zobraziť počet dnešných";
 "showMenuBarAllRemindersCountOptionButton" = "Zobraziť počet všetkých pripomienok";
 "showMenuBarNoCountOptionButton" = "Nezobrazovať počet";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "Povolenie klávesovej skratky na otvorenie %@";
 "keyboardShortcutRestoreDefaultButton" = "Obnoviť predvolené nastavenia";
 "upcomingRemindersIntervalSelectionHelp" = "Vyberte rozsah pre zobrazenie nadchádzajúcich pripomienok";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "Dnes";
 "upcomingRemindersInAWeekTitle" = "Za týždeň";
 "upcomingRemindersInAMonthTitle" = "Za mesiac";

--- a/reminders-menubar/Resources/tr.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/tr.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "Koyu mod";
 "menuBarIconSettingsMenu" = "Menü çubuğu simgesi";
 "menuBarCounterSettingsMenu" = "Menü çubuğu sayacı";
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "Bugünün sayısını göster";
 "showMenuBarAllRemindersCountOptionButton" = "Tüm hatırlatıcıların sayısını göster";
 "showMenuBarNoCountOptionButton" = "Sayacı gösterme";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "%@'ı açmak için klavye kısayolunu etkinleştir";
 "keyboardShortcutRestoreDefaultButton" = "Varsayılanı geri yükle";
 "upcomingRemindersIntervalSelectionHelp" = "Gösterilecek yaklaşan hatırlatıcı aralığını seçin";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "Bugün";
 "upcomingRemindersInAWeekTitle" = "Bir Hafta İçinde";
 "upcomingRemindersInAMonthTitle" = "Bir Ay İçinde";

--- a/reminders-menubar/Resources/uk.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/uk.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "Темний режим";
 "menuBarIconSettingsMenu" = "Смуга меню"; // TODO: Adjust to match "Menu bar icon"
 "menuBarCounterSettingsMenu" = "Menu bar counter"; // TODO: Translate
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "Показати кількість на сьогодні";
 "showMenuBarAllRemindersCountOptionButton" = "Show all reminders count"; // TODO: Translate
 "showMenuBarNoCountOptionButton" = "Don't show count"; // TODO: Translate
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "Увімкнути комбінацію клавіш, щоб відкрити %@";
 "keyboardShortcutRestoreDefaultButton" = "Відновити значення за замовчуванням";
 "upcomingRemindersIntervalSelectionHelp" = "Виберіть діапазон майбутніх нагадувань для показу";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "Сьогодні";
 "upcomingRemindersInAWeekTitle" = "За тиждень";
 "upcomingRemindersInAMonthTitle" = "За місяць";

--- a/reminders-menubar/Resources/vi.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/vi.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "Chế độ tối";
 "menuBarIconSettingsMenu" = "Biểu tượng ở thanh menu";
 "menuBarCounterSettingsMenu" = "Bộ đếm ở thanh menu";
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "Hiển thị số lượng ngày hôm nay";
 "showMenuBarAllRemindersCountOptionButton" = "Hiển thị tất cả số lượng lời nhắc";
 "showMenuBarNoCountOptionButton" = "Không hiển thị số lượng";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "Cho phép kích hoạt phím tắt để mở %@";
 "keyboardShortcutRestoreDefaultButton" = "Khôi phục lại mặc định";
 "upcomingRemindersIntervalSelectionHelp" = "Chọn phạm vi lời nhắc để được hiển thị";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "Hôm nay";
 "upcomingRemindersInAWeekTitle" = "Trong một tuần";
 "upcomingRemindersInAMonthTitle" = "Trong một tháng";

--- a/reminders-menubar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/reminders-menubar/Resources/zh-Hans.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "appAppearanceColorDarkModeOptionButton" = "深色模式";
 "menuBarIconSettingsMenu" = "菜单栏图标";
 "menuBarCounterSettingsMenu" = "菜单栏计数";
+"showMenuBarDueCountOptionButton" = "Show due count"; // TODO: translate
 "showMenuBarTodayCountOptionButton" = "显示今日计数";
 "showMenuBarAllRemindersCountOptionButton" = "显示所有计数";
 "showMenuBarNoCountOptionButton" = "不显示计数";
@@ -58,6 +59,7 @@
 "keyboardShortcutEnableOpenShortcutOption" = "启用键盘快捷键打开 %@";
 "keyboardShortcutRestoreDefaultButton" = "恢复默认";
 "upcomingRemindersIntervalSelectionHelp" = "选择需要显示的提醒事项";
+"upcomingRemindersDueTitle" = "Due"; // TODO: translate
 "upcomingRemindersTodayTitle" = "今天";
 "upcomingRemindersInAWeekTitle" = "本周";
 "upcomingRemindersInAMonthTitle" = "本月";

--- a/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
+++ b/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
@@ -169,32 +169,11 @@ struct SettingsBarGearMenu: View {
     
     func menuBarCounterMenu() -> some View {
         Menu {
-            Button(action: {
-                userPreferences.menuBarCounterType = .due
-            }) {
-                let isSelected = userPreferences.menuBarCounterType == .due
-                SelectableView(title: rmbLocalized(.showMenuBarDueCountOptionButton), isSelected: isSelected)
-            }
-
-            Button(action: {
-                userPreferences.menuBarCounterType = .today
-            }) {
-                let isSelected = userPreferences.menuBarCounterType == .today
-                SelectableView(title: rmbLocalized(.showMenuBarTodayCountOptionButton), isSelected: isSelected)
-            }
-            
-            Button(action: {
-                userPreferences.menuBarCounterType = .allReminders
-            }) {
-                let isSelected = userPreferences.menuBarCounterType == .allReminders
-                SelectableView(title: rmbLocalized(.showMenuBarAllRemindersCountOptionButton), isSelected: isSelected)
-            }
-            
-            Button(action: {
-                userPreferences.menuBarCounterType = .disabled
-            }) {
-                let isSelected = userPreferences.menuBarCounterType == .disabled
-                SelectableView(title: rmbLocalized(.showMenuBarNoCountOptionButton), isSelected: isSelected)
+            ForEach(RmbMenuBarCounterType.allCases, id: \.rawValue) {countType in
+                Button(action: { userPreferences.menuBarCounterType = countType }) {
+                    let isSelected = countType ==  userPreferences.menuBarCounterType
+                    SelectableView(title: countType.title, isSelected: isSelected)
+                }
             }
         } label: {
             Text(rmbLocalized(.menuBarCounterSettingsMenu))

--- a/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
+++ b/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
@@ -170,6 +170,13 @@ struct SettingsBarGearMenu: View {
     func menuBarCounterMenu() -> some View {
         Menu {
             Button(action: {
+                userPreferences.menuBarCounterType = .due
+            }) {
+                let isSelected = userPreferences.menuBarCounterType == .due
+                SelectableView(title: rmbLocalized(.showMenuBarDueCountOptionButton), isSelected: isSelected)
+            }
+
+            Button(action: {
                 userPreferences.menuBarCounterType = .today
             }) {
                 let isSelected = userPreferences.menuBarCounterType == .today


### PR DESCRIPTION
I prefer when the menubar only alerts me to reminders that are actually due, so I actually pay attention to it :)

So I added the 'Due' option to the menubar counter (and to _Upcoming reminders_ for those who really don't want to see reminders later in the day!)

<img width="400" src="https://github.com/DamascenoRafael/reminders-menubar/assets/13365217/a66acaa0-97ee-46ce-9cc0-2ae8b96e9c07">
<img width="300" src="https://github.com/DamascenoRafael/reminders-menubar/assets/13365217/a47f14e0-d7de-4210-98a3-57e23c32a6c4">

Pretty simple case of extending the  `ReminderInterval` and `RmbMenuBarCounterType` enums such that the filter reaches to now rather than the end of the day.

## Localization

Two extra strings added:
```
"showMenuBarDueCountOptionButton" = "Show due count";
"upcomingRemindersDueTitle" = "Due";
```
and translated into German by myself & into Polish by my friend Felka.