### PR TITLE
Checkmark for menubar selection

### DIFF
--- a/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
+++ b/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
@@ -158,8 +158,9 @@ struct SettingsBarGearMenu: View {
                     userPreferences.reminderMenuBarIcon = icon
                     AppDelegate.shared.loadMenuBarIcon()
                 }) {
+                    let isSelected = userPreferences.reminderMenuBarIcon == icon
                     Image(nsImage: icon.image)
-                    Text(icon.name)
+                    Text((isSelected ? "✓\t" : "\t") + icon.name)
                 }
             }
         } label: {


### PR DESCRIPTION
<img width="405" src="https://github.com/DamascenoRafael/reminders-menubar/assets/13365217/b84e4702-35eb-4c86-83fe-1ec7f8094700">

This is for no other reason than aesthetics while I'm familiarising myself more with the codebase.

I figured it would be a cute edit (it was a little disconcerting without a checkmark!), but let me know if it's not your style!