### PR TITLE
Add Filtered Reminders Options to MenuBarCount and UpcomingReminders

### DIFF
--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -83,6 +83,8 @@ class RemindersData: ObservableObject {
                     )
 
                     self.upcomingReminders = await self.getFilteredUpcomingReminders()
+                    let count = await self.getMenuBarCount(UserPreferences.shared.menuBarCounterType)
+                    self.updateMenuBarCount(with: count)
                 }
             }
             .store(in: &cancellationTokens)

--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -54,18 +54,16 @@ class RemindersData: ObservableObject {
             }
             .store(in: &cancellationTokens)
 
-
         userPreferences.$upcomingRemindersInterval
             .dropFirst()
             .sink { [weak self] _ in
                 Task {
-                    guard let self = self else { return }
+                    guard let self else { return }
                     self.upcomingReminders = await self.getFilteredUpcomingReminders()
                 }
             }
             .store(in: &cancellationTokens)
 
-        
         userPreferences.$filterUpcomingRemindersByCalendar
             .dropFirst()
             .sink { [weak self] _ in
@@ -81,7 +79,7 @@ class RemindersData: ObservableObject {
             .dropFirst()
             .sink { [weak self] calendarIdentifiersFilter in
                 Task {
-                    guard let self = self else { return }
+                    guard let self else { return }
                     self.filteredReminderLists = await RemindersService.shared.getReminders(
                         of: calendarIdentifiersFilter
                     )
@@ -90,7 +88,6 @@ class RemindersData: ObservableObject {
                 }
             }
             .store(in: &cancellationTokens)
-
     }
 
     @Published var calendars: [EKCalendar] = []

--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -149,29 +149,28 @@ class RemindersData: ObservableObject {
     }
     
     private func getFilteredUpcomingReminders() async -> [ReminderItem] {
-        let shouldFilter = UserPreferences.shared.filterUpcomingRemindersByCalendar
-        let filters = shouldFilter ? self.calendarIdentifiersFilter : nil
+        let calendarFilter = UserPreferences.shared.filterUpcomingRemindersByCalendar
+            ? self.calendarIdentifiersFilter
+            : nil
 
-        let upcomingRemindersInterval = self.userPreferences.upcomingRemindersInterval
-        let upcomingReminders = await RemindersService.shared.getUpcomingReminders(
-            upcomingRemindersInterval,
-            for: filters
+        return await RemindersService.shared.getUpcomingReminders(
+            UserPreferences.shared.upcomingRemindersInterval,
+            for: calendarFilter
         )
-        
-        return upcomingReminders
     }
 
     private func getMenuBarCount(_ menuBarCounterType: RmbMenuBarCounterType) async -> Int {
-        let shouldFilter = UserPreferences.shared.filterRemindersCountByCalendar
-        let filters = shouldFilter ? self.calendarIdentifiersFilter : nil
+        let calendarFilter = UserPreferences.shared.filterRemindersCountByCalendar
+            ? self.calendarIdentifiersFilter
+            : nil
         
         switch menuBarCounterType {
         case .due:
-            return await RemindersService.shared.getUpcomingReminders(.due, for: filters).count
+            return await RemindersService.shared.getUpcomingReminders(.due, for: calendarFilter).count
         case .today:
-            return await RemindersService.shared.getUpcomingReminders(.today, for: filters).count
+            return await RemindersService.shared.getUpcomingReminders(.today, for: calendarFilter).count
         case .allReminders:
-            return await RemindersService.shared.getUpcomingReminders(.all, for: filters).count
+            return await RemindersService.shared.getUpcomingReminders(.all, for: calendarFilter).count
         case .disabled:
             return -1
         }

--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -41,7 +41,7 @@ class RemindersData: ObservableObject {
             }
             .store(in: &cancellationTokens)
         
-        UserPreferences.shared.$filterRemindersCountByCalendar
+        UserPreferences.shared.$filterMenuBarCountByCalendar
             .dropFirst()
             .sink { [weak self] _ in
                 Task {
@@ -67,7 +67,6 @@ class RemindersData: ObservableObject {
             .sink { [weak self] _ in
                 Task {
                     guard let self else { return }
-                    
                     self.upcomingReminders = await self.getFilteredUpcomingReminders()
                 }
             }
@@ -160,7 +159,7 @@ class RemindersData: ObservableObject {
     }
 
     private func getMenuBarCount(_ menuBarCounterType: RmbMenuBarCounterType) async -> Int {
-        let calendarFilter = UserPreferences.shared.filterRemindersCountByCalendar
+        let calendarFilter = UserPreferences.shared.filterMenuBarCountByCalendar
             ? self.calendarIdentifiersFilter
             : nil
         

--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -132,7 +132,7 @@ class RemindersData: ObservableObject {
         case .today:
             return await RemindersService.shared.getUpcomingReminders(.today).count
         case .filteredReminders:
-            return await RemindersService.shared.getFilteredRemindersCount(of: self.calendarIdentifiersFilter)
+            return await RemindersService.shared.getUpcomingReminders(.all, for: self.calendarIdentifiersFilter).count
         case .allReminders:
             return await RemindersService.shared.getUpcomingReminders(.all).count
         case .disabled:

--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -131,6 +131,8 @@ class RemindersData: ObservableObject {
             return await RemindersService.shared.getUpcomingReminders(.due).count
         case .today:
             return await RemindersService.shared.getUpcomingReminders(.today).count
+        case .filteredReminders:
+            return await RemindersService.shared.getFilteredRemindersCount(of: self.calendarIdentifiersFilter)
         case .allReminders:
             return await RemindersService.shared.getAllRemindersCount()
         case .disabled:

--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -4,8 +4,6 @@ import EventKit
 
 @MainActor
 class RemindersData: ObservableObject {
-    private let userPreferences = UserPreferences.shared
-
     private var cancellationTokens: [AnyCancellable] = []
 
     init() {
@@ -32,7 +30,7 @@ class RemindersData: ObservableObject {
             }
             .store(in: &cancellationTokens)
 
-        userPreferences.$menuBarCounterType
+        UserPreferences.shared.$menuBarCounterType
             .dropFirst()
             .sink { [weak self] menuBarCounterType in
                 Task {
@@ -43,18 +41,18 @@ class RemindersData: ObservableObject {
             }
             .store(in: &cancellationTokens)
         
-        userPreferences.$filterRemindersCountByCalendar
+        UserPreferences.shared.$filterRemindersCountByCalendar
             .dropFirst()
             .sink { [weak self] _ in
                 Task {
                     guard let self else { return }
-                    let count = await self.getMenuBarCount(self.userPreferences.menuBarCounterType)
+                    let count = await self.getMenuBarCount(UserPreferences.shared.menuBarCounterType)
                     self.updateMenuBarCount(with: count)
                 }
             }
             .store(in: &cancellationTokens)
 
-        userPreferences.$upcomingRemindersInterval
+        UserPreferences.shared.$upcomingRemindersInterval
             .dropFirst()
             .sink { [weak self] _ in
                 Task {
@@ -64,7 +62,7 @@ class RemindersData: ObservableObject {
             }
             .store(in: &cancellationTokens)
 
-        userPreferences.$filterUpcomingRemindersByCalendar
+        UserPreferences.shared.$filterUpcomingRemindersByCalendar
             .dropFirst()
             .sink { [weak self] _ in
                 Task {
@@ -140,7 +138,7 @@ class RemindersData: ObservableObject {
         
         let upcomingReminders = await getFilteredUpcomingReminders()
 
-        let menuBarCount = await getMenuBarCount(self.userPreferences.menuBarCounterType)
+        let menuBarCount = await getMenuBarCount(UserPreferences.shared.menuBarCounterType)
 
         self.calendars = calendars
         self.calendarIdentifiersFilter = calendarIdentifiersFilter

--- a/reminders-menubar/Models/RmbMenuBarCounterType.swift
+++ b/reminders-menubar/Models/RmbMenuBarCounterType.swift
@@ -1,7 +1,6 @@
 enum RmbMenuBarCounterType: String, Codable, CaseIterable {
     case due
     case today
-    case filteredReminders
     case allReminders
     case disabled
     
@@ -11,8 +10,6 @@ enum RmbMenuBarCounterType: String, Codable, CaseIterable {
             return rmbLocalized(.showMenuBarDueCountOptionButton)
         case .today:
             return rmbLocalized(.showMenuBarTodayCountOptionButton)
-        case .filteredReminders:
-            return rmbLocalized(.showMenuBarFilteredRemindersCountOptionButton)
         case .allReminders:
             return rmbLocalized(.showMenuBarAllRemindersCountOptionButton)
         case .disabled:

--- a/reminders-menubar/Models/RmbMenuBarCounterType.swift
+++ b/reminders-menubar/Models/RmbMenuBarCounterType.swift
@@ -1,6 +1,7 @@
 enum RmbMenuBarCounterType: String, Codable, CaseIterable {
     case due
     case today
+    case filteredReminders
     case allReminders
     case disabled
     
@@ -10,6 +11,8 @@ enum RmbMenuBarCounterType: String, Codable, CaseIterable {
             return rmbLocalized(.showMenuBarDueCountOptionButton)
         case .today:
             return rmbLocalized(.showMenuBarTodayCountOptionButton)
+        case .filteredReminders:
+            return rmbLocalized(.showMenuBarFilteredRemindersCountOptionButton)
         case .allReminders:
             return rmbLocalized(.showMenuBarAllRemindersCountOptionButton)
         case .disabled:

--- a/reminders-menubar/Resources/Localizable.xcstrings
+++ b/reminders-menubar/Resources/Localizable.xcstrings
@@ -3091,7 +3091,7 @@
         }
       }
     },
-    "filterUpcomingRemindersOptionButton" : {
+    "filterUpcomingRemindersByCalendarOptionButton" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {

--- a/reminders-menubar/Resources/Localizable.xcstrings
+++ b/reminders-menubar/Resources/Localizable.xcstrings
@@ -218,16 +218,16 @@
     "appAppearanceColorDarkModeOptionButton" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dark mode"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dunkler Modus"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dark mode"
           }
         },
         "fr" : {
@@ -313,16 +313,16 @@
     "appAppearanceColorLightModeOptionButton" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Light mode"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Heller Modus"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light mode"
           }
         },
         "fr" : {
@@ -408,16 +408,16 @@
     "appAppearanceColorSystemModeOptionButton" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System appearance"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Systemeinstellung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System appearance"
           }
         },
         "fr" : {
@@ -3073,7 +3073,7 @@
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Filter by selected lists"
           }
         },
@@ -3081,6 +3081,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filtrer à partir des listes séléctionneés"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrar pelas listas selecionadas"
           }
         }
       }
@@ -3090,14 +3096,20 @@
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Filter by selected list"
+            "state" : "translated",
+            "value" : "Filter by selected lists"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Filtrer à partir des listes séléctionneés"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrar pelas listas selecionadas"
           }
         }
       }
@@ -3640,16 +3652,16 @@
     "menuBarCounterSettingsMenu" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menu bar counter"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Anzahl in Menüleiste"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menu bar counter"
           }
         },
         "fr" : {
@@ -5120,24 +5132,6 @@
     "reminderRecurrenceDailyLabel" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Daily"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Every %i days"
-                }
-              }
-            }
-          }
-        },
         "de" : {
           "variations" : {
             "plural" : {
@@ -5151,6 +5145,24 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "Alle %i Tage"
+                }
+              }
+            }
+          }
+        },
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Daily"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Every %i days"
                 }
               }
             }
@@ -5197,24 +5209,6 @@
     "reminderRecurrenceMonthlyLabel" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Monthly"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Every %i months"
-                }
-              }
-            }
-          }
-        },
         "de" : {
           "variations" : {
             "plural" : {
@@ -5228,6 +5222,24 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "Alle %i Monate"
+                }
+              }
+            }
+          }
+        },
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Monthly"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Every %i months"
                 }
               }
             }
@@ -5274,24 +5286,6 @@
     "reminderRecurrenceWeeklyLabel" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Weekly"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Every %i weeks"
-                }
-              }
-            }
-          }
-        },
         "de" : {
           "variations" : {
             "plural" : {
@@ -5305,6 +5299,24 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "Alle %i Wochen"
+                }
+              }
+            }
+          }
+        },
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Weekly"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Every %i weeks"
                 }
               }
             }
@@ -5351,24 +5363,6 @@
     "reminderRecurrenceYearlyLabel" : {
       "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Yearly"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Every %i years"
-                }
-              }
-            }
-          }
-        },
         "de" : {
           "variations" : {
             "plural" : {
@@ -5382,6 +5376,24 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "Alle %i Jahre"
+                }
+              }
+            }
+          }
+        },
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Yearly"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Every %i years"
                 }
               }
             }

--- a/reminders-menubar/Resources/Localizable.xcstrings
+++ b/reminders-menubar/Resources/Localizable.xcstrings
@@ -5122,6 +5122,24 @@
             }
           }
         },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Tous les jours"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Tous les %i jours"
+                }
+              }
+            }
+          }
+        },
         "pt-BR" : {
           "variations" : {
             "plural" : {
@@ -5176,6 +5194,24 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "Alle %i Monate"
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Tous les mois"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Tous les %i mois"
                 }
               }
             }
@@ -5240,6 +5276,24 @@
             }
           }
         },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Toutes les semaines"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Toutes les %i semaines"
+                }
+              }
+            }
+          }
+        },
         "pt-BR" : {
           "variations" : {
             "plural" : {
@@ -5294,6 +5348,24 @@
                 "stringUnit" : {
                   "state" : "translated",
                   "value" : "Alle %i Jahre"
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Tous les ans"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Tous les %i ans"
                 }
               }
             }
@@ -6412,8 +6484,8 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Sélectionnez le calendrier où les nouveaux rappels seront sauvegardés"
+            "state" : "translated",
+            "value" : "Sélectionnez la liste où les nouveaux rappels seront sauvegardés"
           }
         },
         "it" : {
@@ -7162,6 +7234,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Due"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En retard"
           }
         },
         "it" : {

--- a/reminders-menubar/Resources/Localizable.xcstrings
+++ b/reminders-menubar/Resources/Localizable.xcstrings
@@ -3074,13 +3074,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Apply filter"
+            "value" : "Filter by selected lists"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Appliquer le filtrage"
+            "value" : "Filtrer à partir des listes séléctionneés"
           }
         }
       }

--- a/reminders-menubar/Resources/Localizable.xcstrings
+++ b/reminders-menubar/Resources/Localizable.xcstrings
@@ -6814,6 +6814,12 @@
             "value" : "Show due count"
           }
         },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les rappels en retard"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",

--- a/reminders-menubar/Resources/Localizable.xcstrings
+++ b/reminders-menubar/Resources/Localizable.xcstrings
@@ -3085,6 +3085,23 @@
         }
       }
     },
+    "filterUpcomingRemindersOptionButton" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Filter by selected list"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrer à partir des listes séléctionneés"
+          }
+        }
+      }
+    },
     "keyboardShortcutEnableOpenShortcutOption" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/reminders-menubar/Resources/Localizable.xcstrings
+++ b/reminders-menubar/Resources/Localizable.xcstrings
@@ -3086,7 +3086,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Filtrar pelas listas selecionadas"
+            "value" : "Filtrar por listas selecionadas"
           }
         }
       }
@@ -3109,7 +3109,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Filtrar pelas listas selecionadas"
+            "value" : "Filtrar por listas selecionadas"
           }
         }
       }

--- a/reminders-menubar/Resources/Localizable.xcstrings
+++ b/reminders-menubar/Resources/Localizable.xcstrings
@@ -3068,6 +3068,23 @@
         }
       }
     },
+    "filterMenuBarCountByCalendarOptionButton" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apply filter"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appliquer le filtrage"
+          }
+        }
+      }
+    },
     "keyboardShortcutEnableOpenShortcutOption" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -6914,23 +6931,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示到期計數選項按鈕"
-          }
-        }
-      }
-    },
-    "showMenuBarFilteredRemindersCountOptionButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show filtered reminders count"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher les rappels filtrés"
           }
         }
       }

--- a/reminders-menubar/Resources/Localizable.xcstrings
+++ b/reminders-menubar/Resources/Localizable.xcstrings
@@ -6918,6 +6918,23 @@
         }
       }
     },
+    "showMenuBarFilteredRemindersCountOptionButton" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show filtered reminders count"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les rappels filtrés"
+          }
+        }
+      }
+    },
     "showMenuBarNoCountOptionButton" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/reminders-menubar/Resources/remindersLocalized.swift
+++ b/reminders-menubar/Resources/remindersLocalized.swift
@@ -48,7 +48,6 @@ enum RemindersMenuBarLocalizedKeys: String {
     case filterMenuBarCountByCalendarOptionButton
     case showMenuBarDueCountOptionButton
     case showMenuBarTodayCountOptionButton
-    case showMenuBarFilteredRemindersCountOptionButton
     case showMenuBarAllRemindersCountOptionButton
     case showMenuBarNoCountOptionButton
     case keyboardShortcutOptionButton

--- a/reminders-menubar/Resources/remindersLocalized.swift
+++ b/reminders-menubar/Resources/remindersLocalized.swift
@@ -69,7 +69,7 @@ enum RemindersMenuBarLocalizedKeys: String {
     case upcomingRemindersInAWeekTitle
     case upcomingRemindersInAMonthTitle
     case upcomingRemindersAllTitle
-    case filterUpcomingRemindersOptionButton
+    case filterUpcomingRemindersByCalendarOptionButton // swiftlint:disable:this identifier_name
     case appNoRemindersAccessAlertMessage
     case appNoRemindersAccessAlertDescription
     case openSystemPreferencesButton

--- a/reminders-menubar/Resources/remindersLocalized.swift
+++ b/reminders-menubar/Resources/remindersLocalized.swift
@@ -47,6 +47,7 @@ enum RemindersMenuBarLocalizedKeys: String {
     case menuBarCounterSettingsMenu
     case showMenuBarDueCountOptionButton
     case showMenuBarTodayCountOptionButton
+    case showMenuBarFilteredRemindersCountOptionButton
     case showMenuBarAllRemindersCountOptionButton
     case showMenuBarNoCountOptionButton
     case keyboardShortcutOptionButton

--- a/reminders-menubar/Resources/remindersLocalized.swift
+++ b/reminders-menubar/Resources/remindersLocalized.swift
@@ -45,6 +45,7 @@ enum RemindersMenuBarLocalizedKeys: String {
     case appAppearanceColorDarkModeOptionButton
     case menuBarIconSettingsMenu
     case menuBarCounterSettingsMenu
+    case filterMenuBarCountByCalendarOptionButton
     case showMenuBarDueCountOptionButton
     case showMenuBarTodayCountOptionButton
     case showMenuBarFilteredRemindersCountOptionButton

--- a/reminders-menubar/Resources/remindersLocalized.swift
+++ b/reminders-menubar/Resources/remindersLocalized.swift
@@ -69,6 +69,7 @@ enum RemindersMenuBarLocalizedKeys: String {
     case upcomingRemindersInAWeekTitle
     case upcomingRemindersInAMonthTitle
     case upcomingRemindersAllTitle
+    case filterUpcomingRemindersOptionButton
     case appNoRemindersAccessAlertMessage
     case appNoRemindersAccessAlertDescription
     case openSystemPreferencesButton

--- a/reminders-menubar/Services/RemindersService.swift
+++ b/reminders-menubar/Services/RemindersService.swift
@@ -98,6 +98,15 @@ class RemindersService {
         return reminders.count
     }
     
+    func getFilteredRemindersCount(of calendarIdentifiers: [String]) async -> Int {
+        let calendars = getCalendars().filter({ calendarIdentifiers.contains($0.calendarIdentifier) })
+        let predicate = eventStore.predicateForIncompleteReminders(withDueDateStarting: nil,
+                                                                   ending: nil,
+                                                                   calendars: calendars)
+        let reminders = await fetchReminders(matching: predicate)
+        return reminders.count
+    }
+    
     func save(reminder: EKReminder) {
         do {
             try eventStore.save(reminder, commit: true)

--- a/reminders-menubar/Services/RemindersService.swift
+++ b/reminders-menubar/Services/RemindersService.swift
@@ -84,7 +84,11 @@ class RemindersService {
     func getUpcomingReminders(_ interval: ReminderInterval,
                               for calendarIdentifiers: [String]? = nil) async -> [ReminderItem] {
         var calendars: [EKCalendar]?
-        if let calendarIdentifiers, !calendarIdentifiers.isEmpty {
+        if let calendarIdentifiers {
+            if calendarIdentifiers.isEmpty {
+                // If the filter does not have any calendar selected, return empty
+                return []
+            }
             calendars = getCalendars().filter({ calendarIdentifiers.contains($0.calendarIdentifier) })
         }
         let predicate = eventStore.predicateForIncompleteReminders(withDueDateStarting: nil,

--- a/reminders-menubar/Services/UserPreferences.swift
+++ b/reminders-menubar/Services/UserPreferences.swift
@@ -13,6 +13,7 @@ private struct PreferencesKeys {
     static let showUpcomingReminders = "showUpcomingReminders"
     static let upcomingRemindersInterval = "upcomingRemindersInterval"
     static let menuBarCounterType = "menuBarCounterType"
+    static let filterRemindersCountByCalendar = "filterRemindersCountByCalendar"
     static let preferredLanguage = "preferredLanguage"
 }
 
@@ -149,6 +150,14 @@ class UserPreferences: ObservableObject {
         didSet {
             let counterTypeData = try? JSONEncoder().encode(menuBarCounterType)
             UserPreferences.defaults.set(counterTypeData, forKey: PreferencesKeys.menuBarCounterType)
+        }
+    }
+    
+    @Published var filterRemindersCountByCalendar: Bool = {
+        return defaults.bool(forKey: PreferencesKeys.filterRemindersCountByCalendar)
+    }() {
+        didSet {
+            UserPreferences.defaults.set(filterRemindersCountByCalendar, forKey: PreferencesKeys.filterRemindersCountByCalendar)
         }
     }
     

--- a/reminders-menubar/Services/UserPreferences.swift
+++ b/reminders-menubar/Services/UserPreferences.swift
@@ -12,6 +12,7 @@ private struct PreferencesKeys {
     static let backgroundIsTransparent = "backgroundIsTransparent"
     static let showUpcomingReminders = "showUpcomingReminders"
     static let upcomingRemindersInterval = "upcomingRemindersInterval"
+    static let filterUpcomingRemindersByCalendar = "filterUpcomingRemindersByCalendar"
     static let menuBarCounterType = "menuBarCounterType"
     static let filterRemindersCountByCalendar = "filterRemindersCountByCalendar"
     static let preferredLanguage = "preferredLanguage"
@@ -91,6 +92,14 @@ class UserPreferences: ObservableObject {
         didSet {
             let intervalData = try? JSONEncoder().encode(upcomingRemindersInterval)
             UserPreferences.defaults.set(intervalData, forKey: PreferencesKeys.upcomingRemindersInterval)
+        }
+    }
+    
+    @Published var filterUpcomingRemindersByCalendar: Bool = {
+        return defaults.bool(forKey: PreferencesKeys.filterUpcomingRemindersByCalendar)
+    }() {
+        didSet {
+            UserPreferences.defaults.set(filterUpcomingRemindersByCalendar, forKey: PreferencesKeys.filterUpcomingRemindersByCalendar)
         }
     }
     

--- a/reminders-menubar/Services/UserPreferences.swift
+++ b/reminders-menubar/Services/UserPreferences.swift
@@ -14,7 +14,7 @@ private struct PreferencesKeys {
     static let upcomingRemindersInterval = "upcomingRemindersInterval"
     static let filterUpcomingRemindersByCalendar = "filterUpcomingRemindersByCalendar"
     static let menuBarCounterType = "menuBarCounterType"
-    static let filterRemindersCountByCalendar = "filterRemindersCountByCalendar"
+    static let filterMenuBarCountByCalendar = "filterMenuBarCountByCalendar"
     static let preferredLanguage = "preferredLanguage"
 }
 
@@ -99,7 +99,8 @@ class UserPreferences: ObservableObject {
         return defaults.bool(forKey: PreferencesKeys.filterUpcomingRemindersByCalendar)
     }() {
         didSet {
-            UserPreferences.defaults.set(filterUpcomingRemindersByCalendar, forKey: PreferencesKeys.filterUpcomingRemindersByCalendar)
+            UserPreferences.defaults.set(filterUpcomingRemindersByCalendar,
+                                         forKey: PreferencesKeys.filterUpcomingRemindersByCalendar)
         }
     }
     
@@ -162,11 +163,12 @@ class UserPreferences: ObservableObject {
         }
     }
     
-    @Published var filterRemindersCountByCalendar: Bool = {
-        return defaults.bool(forKey: PreferencesKeys.filterRemindersCountByCalendar)
+    @Published var filterMenuBarCountByCalendar: Bool = {
+        return defaults.bool(forKey: PreferencesKeys.filterMenuBarCountByCalendar)
     }() {
         didSet {
-            UserPreferences.defaults.set(filterRemindersCountByCalendar, forKey: PreferencesKeys.filterRemindersCountByCalendar)
+            UserPreferences.defaults.set(filterMenuBarCountByCalendar,
+                                         forKey: PreferencesKeys.filterMenuBarCountByCalendar)
         }
     }
     

--- a/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
+++ b/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
@@ -169,6 +169,15 @@ struct SettingsBarGearMenu: View {
     
     func menuBarCounterMenu() -> some View {
         Menu {
+            Button(action: {
+                userPreferences.filterRemindersCountByCalendar.toggle()
+            }) {
+                SelectableView(title: rmbLocalized(.filterMenuBarCountByCalendarOptionButton),
+                               isSelected: userPreferences.filterRemindersCountByCalendar)
+            }
+            
+            Divider()
+            
             ForEach(RmbMenuBarCounterType.allCases, id: \.rawValue) { counterType in
                 Button(action: { userPreferences.menuBarCounterType = counterType }) {
                     let isSelected = counterType == userPreferences.menuBarCounterType

--- a/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
+++ b/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
@@ -179,10 +179,10 @@ struct SettingsBarGearMenu: View {
             Divider()
             
             Button(action: {
-                userPreferences.filterRemindersCountByCalendar.toggle()
+                userPreferences.filterMenuBarCountByCalendar.toggle()
             }) {
                 SelectableView(title: rmbLocalized(.filterMenuBarCountByCalendarOptionButton),
-                               isSelected: userPreferences.filterRemindersCountByCalendar)
+                               isSelected: userPreferences.filterMenuBarCountByCalendar)
             }
         } label: {
             Text(rmbLocalized(.menuBarCounterSettingsMenu))

--- a/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
+++ b/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
@@ -169,14 +169,6 @@ struct SettingsBarGearMenu: View {
     
     func menuBarCounterMenu() -> some View {
         Menu {
-            Button(action: {
-                userPreferences.filterRemindersCountByCalendar.toggle()
-            }) {
-                SelectableView(title: rmbLocalized(.filterMenuBarCountByCalendarOptionButton),
-                               isSelected: userPreferences.filterRemindersCountByCalendar)
-            }
-            
-            Divider()
             
             ForEach(RmbMenuBarCounterType.allCases, id: \.rawValue) { counterType in
                 Button(action: { userPreferences.menuBarCounterType = counterType }) {
@@ -184,6 +176,16 @@ struct SettingsBarGearMenu: View {
                     SelectableView(title: counterType.title, isSelected: isSelected)
                 }
             }
+            
+            Divider()
+            
+            Button(action: {
+                userPreferences.filterRemindersCountByCalendar.toggle()
+            }) {
+                SelectableView(title: rmbLocalized(.filterMenuBarCountByCalendarOptionButton),
+                               isSelected: userPreferences.filterRemindersCountByCalendar)
+            }
+            
         } label: {
             Text(rmbLocalized(.menuBarCounterSettingsMenu))
         }

--- a/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
+++ b/reminders-menubar/Views/SettingsBarView/SettingsBarGearMenu.swift
@@ -169,7 +169,6 @@ struct SettingsBarGearMenu: View {
     
     func menuBarCounterMenu() -> some View {
         Menu {
-            
             ForEach(RmbMenuBarCounterType.allCases, id: \.rawValue) { counterType in
                 Button(action: { userPreferences.menuBarCounterType = counterType }) {
                     let isSelected = counterType == userPreferences.menuBarCounterType
@@ -185,7 +184,6 @@ struct SettingsBarGearMenu: View {
                 SelectableView(title: rmbLocalized(.filterMenuBarCountByCalendarOptionButton),
                                isSelected: userPreferences.filterRemindersCountByCalendar)
             }
-            
         } label: {
             Text(rmbLocalized(.menuBarCounterSettingsMenu))
         }

--- a/reminders-menubar/Views/UpcomingRemindersView/UpcomingRemindersTitle.swift
+++ b/reminders-menubar/Views/UpcomingRemindersView/UpcomingRemindersTitle.swift
@@ -3,9 +3,9 @@ import SwiftUI
 struct UpcomingRemindersTitle: View {
     @ObservedObject var userPreferences = UserPreferences.shared
     @Environment(\.colorSchemeContrast) private var colorSchemeContrast
-    
+
     @State var intervalButtonIsHovered = false
-    
+
     var body: some View {
         HStack(alignment: .center) {
             // TODO: Remove the 'scaledToFit' and 'minimumScaleFactor' properties from the title
@@ -17,9 +17,9 @@ struct UpcomingRemindersTitle: View {
                 .padding(.bottom, 5)
                 .scaledToFit()
                 .minimumScaleFactor(0.8)
-            
+
             Spacer()
-            
+
             Menu {
                 ForEach(ReminderInterval.allCases, id: \.rawValue) { interval in
                     Button(action: { userPreferences.upcomingRemindersInterval = interval }) {
@@ -27,6 +27,16 @@ struct UpcomingRemindersTitle: View {
                         SelectableView(title: interval.title, isSelected: isSelected)
                     }
                 }
+
+                Divider()
+
+                Button(action: {
+                    userPreferences.filterUpcomingRemindersByCalendar.toggle()
+                }) {
+                    SelectableView(title: rmbLocalized(.filterUpcomingRemindersOptionButton),
+                                   isSelected: userPreferences.filterUpcomingRemindersByCalendar)
+                }
+
             } label: {
                 Label(userPreferences.upcomingRemindersInterval.title, systemImage: "calendar")
             }

--- a/reminders-menubar/Views/UpcomingRemindersView/UpcomingRemindersTitle.swift
+++ b/reminders-menubar/Views/UpcomingRemindersView/UpcomingRemindersTitle.swift
@@ -33,7 +33,7 @@ struct UpcomingRemindersTitle: View {
                 Button(action: {
                     userPreferences.filterUpcomingRemindersByCalendar.toggle()
                 }) {
-                    SelectableView(title: rmbLocalized(.filterUpcomingRemindersOptionButton),
+                    SelectableView(title: rmbLocalized(.filterUpcomingRemindersByCalendarOptionButton),
                                    isSelected: userPreferences.filterUpcomingRemindersByCalendar)
                 }
             } label: {

--- a/reminders-menubar/Views/UpcomingRemindersView/UpcomingRemindersTitle.swift
+++ b/reminders-menubar/Views/UpcomingRemindersView/UpcomingRemindersTitle.swift
@@ -36,7 +36,6 @@ struct UpcomingRemindersTitle: View {
                     SelectableView(title: rmbLocalized(.filterUpcomingRemindersOptionButton),
                                    isSelected: userPreferences.filterUpcomingRemindersByCalendar)
                 }
-
             } label: {
                 Label(userPreferences.upcomingRemindersInterval.title, systemImage: "calendar")
             }


### PR DESCRIPTION
When using the filtered reminder menu bar, I thought it would be useful to add an option to display only the count of the reminders you choose to show. So, I introduced a new option to display this count.

The key changes include adding a new case to handle filtered reminders, updating localization files to support this feature, and implementing the logic to compute the count of filtered reminders.

For now, this option does not take the state of the reminders into account (due, today), as I felt it would introduce too many options in the menu. However, this could be considered for a future update.

* [`reminders-menubar/Models/RemindersData.swift`](diffhunk://#diff-2c848f990db06e9350426c9a67a84e9380b9c7176c09897defddce738090a18aR134-R135): Added a new case `filteredReminders` to handle the count of filtered reminders based on calendar identifiers.
* [`reminders-menubar/Models/RmbMenuBarCounterType.swift`](diffhunk://#diff-c1f4fe0c5979f4e1a78e7f6da1b402c7ab9d320082df41544a8cc5289fdf8d8dR4): Added `filteredReminders` to the `RmbMenuBarCounterType` enum.
* [`reminders-menubar/Resources/Localizable.xcstrings`](diffhunk://#diff-fb5602552f00a592c387a51a2f7e4d343687ef226e1ac122380577b512e4a521R6921-R6937): Added localization strings for the new filtered reminders count option button in both English and French.
* [`reminders-menubar/Resources/remindersLocalized.swift`](diffhunk://#diff-0c72ea03f4407c2dbaae15210e5c68b418b379e8c645c64fc009c145e4f34f8aR50): Added a new case `showMenuBarFilteredRemindersCountOptionButton` to the `RemindersMenuBarLocalizedKeys` enum.
* [`reminders-menubar/Services/RemindersService.swift`](diffhunk://#diff-a3a6b9c31002f94be12545bae7dd9420b46bbc9a661d2f7c4eddedb131329816R101-R109): Implemented the `getFilteredRemindersCount` method to fetch and count reminders based on specified calendar identifiers.