### PR TITLE
Automatically open the pop-up if one starts typing

### DIFF
--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -221,9 +221,7 @@ class RemindersData: ObservableObject {
         }
     }
 
-    let createReminderPublisher = PassthroughSubject<String, Never>()
-    var isOpeningCreateReminderSheet = false
-    @Published var pendingCreateReminderTyping = ""
+    @Published var pendingNewReminderTitle: String?
 
     @Published var calendarForSaving: EKCalendar? = {
         guard RemindersService.shared.isAuthorized else {

--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -221,6 +221,8 @@ class RemindersData: ObservableObject {
         }
     }
 
+    let createReminderPublisher = PassthroughSubject<String, Never>()
+
     @Published var calendarForSaving: EKCalendar? = {
         guard RemindersService.shared.isAuthorized else {
             return nil

--- a/reminders-menubar/Models/RemindersData.swift
+++ b/reminders-menubar/Models/RemindersData.swift
@@ -222,6 +222,8 @@ class RemindersData: ObservableObject {
     }
 
     let createReminderPublisher = PassthroughSubject<String, Never>()
+    var isOpeningCreateReminderSheet = false
+    @Published var pendingCreateReminderTyping = ""
 
     @Published var calendarForSaving: EKCalendar? = {
         guard RemindersService.shared.isAuthorized else {

--- a/reminders-menubar/Views/ContentView.swift
+++ b/reminders-menubar/Views/ContentView.swift
@@ -6,10 +6,12 @@ struct ContentView: View {
     @ObservedObject var userPreferences = UserPreferences.shared
     @State private var appHasPopoverOpen = false
     @State private var escapeKeyMonitor: Any?
+    @State private var showingCreateView = false
+    @State private var pendingCreateTitle = ""
 
     var body: some View {
         VStack(spacing: 0) {
-            ToolbarView()
+            ToolbarView(showingCreateView: $showingCreateView)
 
             if remindersData.availableCalendars.isEmpty {
                 emptyStateContent
@@ -37,6 +39,24 @@ struct ContentView: View {
         ) { _ in
             remindersData.showingSearch = false
             remindersData.showingRecentReminders = false
+            showingCreateView = false
+            pendingCreateTitle = ""
+        }
+        .onReceive(remindersData.createReminderPublisher) { title in
+            if showingCreateView {
+                pendingCreateTitle += title
+            } else {
+                pendingCreateTitle = title
+                showingCreateView = true
+            }
+        }
+        .sheet(isPresented: $showingCreateView, onDismiss: {
+            pendingCreateTitle = ""
+        }) {
+            ReminderEditView(
+                isPresented: $showingCreateView,
+                initialTitle: pendingCreateTitle
+            )
         }
     }
 
@@ -45,11 +65,29 @@ struct ContentView: View {
     private func startEscapeKeyMonitor() {
         guard escapeKeyMonitor == nil else { return }
         escapeKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [remindersData] event in
+            let popoverWindow = AppDelegate.shared.popover.contentViewController?.view.window
+
+            // When user types a printable character and no sheet/popover is open, open the create reminder sheet.
+            if !appHasPopoverOpen,
+               popoverWindow?.attachedSheet == nil,
+               !FilterPanelController.shared.isVisible,
+               let characters = event.charactersIgnoringModifiers,
+               characters.count == 1,
+               let scalar = characters.unicodeScalars.first,
+               scalar.value >= 0x20, scalar.value <= 0x7E,
+               !event.modifierFlags.contains(.command),
+               !event.modifierFlags.contains(.option),
+               !event.modifierFlags.contains(.control) {
+
+                let typedText = event.characters ?? characters
+                remindersData.createReminderPublisher.send(typedText)
+                return nil
+            }
+
             guard event.keyCode == RmbKeyCode.escape else { return event }
             // Let other UI layers (edit popovers, filter panel, sheets, alerts) handle their own escape
             guard !appHasPopoverOpen else { return event }
             guard !FilterPanelController.shared.isVisible else { return event }
-            let popoverWindow = AppDelegate.shared.popover.contentViewController?.view.window
             guard popoverWindow?.attachedSheet == nil else { return event }
 
             if remindersData.showingSearch {

--- a/reminders-menubar/Views/ContentView.swift
+++ b/reminders-menubar/Views/ContentView.swift
@@ -59,15 +59,9 @@ struct ContentView: View {
             // When user types a printable character, open the create reminder sheet.
             if !remindersData.showingSearch,
                !remindersData.availableCalendars.isEmpty,
-               popoverWindow.attachedSheet == nil || remindersData.isOpeningCreateReminderSheet,
+               popoverWindow.attachedSheet == nil || remindersData.pendingNewReminderTitle != nil,
                let typedText = printableText(from: event) {
-                if remindersData.isOpeningCreateReminderSheet {
-                    // Buffer text until the sheet is attached and can focus the title field.
-                    remindersData.pendingCreateReminderTyping += typedText
-                } else {
-                    remindersData.isOpeningCreateReminderSheet = true
-                    remindersData.createReminderPublisher.send(typedText)
-                }
+                remindersData.pendingNewReminderTitle = (remindersData.pendingNewReminderTitle ?? "") + typedText
                 return nil
             }
 

--- a/reminders-menubar/Views/ContentView.swift
+++ b/reminders-menubar/Views/ContentView.swift
@@ -5,7 +5,7 @@ struct ContentView: View {
     @EnvironmentObject var remindersData: RemindersData
     @ObservedObject var userPreferences = UserPreferences.shared
     @State private var appHasPopoverOpen = false
-    @State private var escapeKeyMonitor: Any?
+    @State private var keyMonitor: Any?
     @State private var showingCreateView = false
     @State private var pendingCreateTitle = ""
 
@@ -29,7 +29,7 @@ struct ContentView: View {
         .modifier(RmbBackgroundModifier())
         .preferredColorScheme(userPreferences.rmbColorScheme.colorScheme)
         .environment(\.appHasPopoverOpen, $appHasPopoverOpen)
-        .onAppear { startEscapeKeyMonitor() }
+        .onAppear { startKeyMonitor() }
         .onDisappear { stopEscapeKeyMonitor() }
         .onReceive(
             NotificationCenter.default.publisher(
@@ -62,9 +62,9 @@ struct ContentView: View {
 
     // MARK: - Escape key handling
 
-    private func startEscapeKeyMonitor() {
-        guard escapeKeyMonitor == nil else { return }
-        escapeKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [remindersData] event in
+    private func startKeyMonitor() {
+        guard keyMonitor == nil else { return }
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [remindersData] event in
             let popoverWindow = AppDelegate.shared.popover.contentViewController?.view.window
 
             // When user types a printable character and no sheet/popover is open, open the create reminder sheet.
@@ -105,9 +105,9 @@ struct ContentView: View {
     }
 
     private func stopEscapeKeyMonitor() {
-        if let monitor = escapeKeyMonitor {
+        if let monitor = keyMonitor {
             NSEvent.removeMonitor(monitor)
-            escapeKeyMonitor = nil
+            keyMonitor = nil
         }
     }
 

--- a/reminders-menubar/Views/ContentView.swift
+++ b/reminders-menubar/Views/ContentView.swift
@@ -30,7 +30,7 @@ struct ContentView: View {
         .preferredColorScheme(userPreferences.rmbColorScheme.colorScheme)
         .environment(\.appHasPopoverOpen, $appHasPopoverOpen)
         .onAppear { startKeyMonitor() }
-        .onDisappear { stopEscapeKeyMonitor() }
+        .onDisappear { stopKeyMonitor() }
         .onReceive(
             NotificationCenter.default.publisher(
                 for: NSPopover.didCloseNotification,
@@ -102,7 +102,7 @@ struct ContentView: View {
         }
     }
 
-    private func stopEscapeKeyMonitor() {
+    private func stopKeyMonitor() {
         if let monitor = keyMonitor {
             NSEvent.removeMonitor(monitor)
             keyMonitor = nil

--- a/reminders-menubar/Views/ContentView.swift
+++ b/reminders-menubar/Views/ContentView.swift
@@ -40,32 +40,38 @@ struct ContentView: View {
         }
     }
 
-    // MARK: - Escape key handling
+    // MARK: - Key handling
 
     private func startKeyMonitor() {
         guard keyMonitor == nil else { return }
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [remindersData] event in
-            let popoverWindow = AppDelegate.shared.popover.contentViewController?.view.window
+            let popover = AppDelegate.shared.popover
+            guard popover.isShown,
+                  let popoverWindow = popover.contentViewController?.view.window,
+                  event.window === popoverWindow else {
+                return event
+            }
 
             // Let other UI layers (edit popovers, filter panel, sheets, alerts) handle their own keys
             guard !appHasPopoverOpen else { return event }
             guard !FilterPanelController.shared.isVisible else { return event }
-            guard popoverWindow?.attachedSheet == nil else { return event }
 
             // When user types a printable character, open the create reminder sheet.
-            if let characters = event.charactersIgnoringModifiers,
-               characters.count == 1,
-               let scalar = characters.unicodeScalars.first,
-               scalar.value >= 0x20, scalar.value <= 0x7E,
-               !event.modifierFlags.contains(.command),
-               !event.modifierFlags.contains(.option),
-               !event.modifierFlags.contains(.control) {
-
-                let typedText = event.characters ?? characters
-                remindersData.createReminderPublisher.send(typedText)
+            if !remindersData.showingSearch,
+               !remindersData.availableCalendars.isEmpty,
+               popoverWindow.attachedSheet == nil || remindersData.isOpeningCreateReminderSheet,
+               let typedText = printableText(from: event) {
+                if remindersData.isOpeningCreateReminderSheet {
+                    // Buffer text until the sheet is attached and can focus the title field.
+                    remindersData.pendingCreateReminderTyping += typedText
+                } else {
+                    remindersData.isOpeningCreateReminderSheet = true
+                    remindersData.createReminderPublisher.send(typedText)
+                }
                 return nil
             }
 
+            guard popoverWindow.attachedSheet == nil else { return event }
             guard event.keyCode == RmbKeyCode.escape else { return event }
 
             if remindersData.showingSearch {
@@ -80,6 +86,18 @@ struct ContentView: View {
             AppDelegate.shared.popover.performClose(nil)
             return nil
         }
+    }
+
+    private func printableText(from event: NSEvent) -> String? {
+        let shortcutModifiers: NSEvent.ModifierFlags = [.command, .control]
+        guard event.modifierFlags.intersection(shortcutModifiers).isEmpty,
+              let characters = event.characters,
+              !characters.isEmpty,
+              characters.unicodeScalars.allSatisfy(\.isPrintable) else {
+            return nil
+        }
+
+        return characters
     }
 
     private func stopKeyMonitor() {
@@ -169,6 +187,17 @@ struct ContentView: View {
     @ViewBuilder private var noFilterContent: some View {
         NoFilterSelectedView()
             .frame(maxHeight: .infinity)
+    }
+}
+
+private extension Unicode.Scalar {
+    var isPrintable: Bool {
+        switch properties.generalCategory {
+        case .control, .format, .surrogate, .privateUse, .unassigned:
+            return false
+        default:
+            return true
+        }
     }
 }
 

--- a/reminders-menubar/Views/ContentView.swift
+++ b/reminders-menubar/Views/ContentView.swift
@@ -6,12 +6,10 @@ struct ContentView: View {
     @ObservedObject var userPreferences = UserPreferences.shared
     @State private var appHasPopoverOpen = false
     @State private var keyMonitor: Any?
-    @State private var showingCreateView = false
-    @State private var pendingCreateTitle = ""
 
     var body: some View {
         VStack(spacing: 0) {
-            ToolbarView(showingCreateView: $showingCreateView)
+            ToolbarView()
 
             if remindersData.availableCalendars.isEmpty {
                 emptyStateContent
@@ -39,24 +37,6 @@ struct ContentView: View {
         ) { _ in
             remindersData.showingSearch = false
             remindersData.showingRecentReminders = false
-            showingCreateView = false
-            pendingCreateTitle = ""
-        }
-        .onReceive(remindersData.createReminderPublisher) { title in
-            if showingCreateView {
-                pendingCreateTitle += title
-            } else {
-                pendingCreateTitle = title
-                showingCreateView = true
-            }
-        }
-        .sheet(isPresented: $showingCreateView, onDismiss: {
-            pendingCreateTitle = ""
-        }) {
-            ReminderEditView(
-                isPresented: $showingCreateView,
-                initialTitle: pendingCreateTitle
-            )
         }
     }
 

--- a/reminders-menubar/Views/ContentView.swift
+++ b/reminders-menubar/Views/ContentView.swift
@@ -44,50 +44,71 @@ struct ContentView: View {
 
     private func startKeyMonitor() {
         guard keyMonitor == nil else { return }
-        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [remindersData] event in
-            let popover = AppDelegate.shared.popover
-            guard popover.isShown,
-                  let popoverWindow = popover.contentViewController?.view.window,
-                  event.window === popoverWindow else {
-                return event
-            }
-
-            // Let other UI layers (edit popovers, filter panel, sheets, alerts) handle their own keys
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard let popoverWindow = activePopoverWindow(for: event) else { return event }
             guard !appHasPopoverOpen else { return event }
             guard !FilterPanelController.shared.isVisible else { return event }
 
-            // When user types a printable character, open the create reminder sheet.
-            if !remindersData.showingSearch,
-               !remindersData.availableCalendars.isEmpty,
-               popoverWindow.attachedSheet == nil || remindersData.pendingNewReminderTitle != nil,
-               let typedText = printableText(from: event) {
-                remindersData.pendingNewReminderTitle = (remindersData.pendingNewReminderTitle ?? "") + typedText
+            if handlePrintableKey(event, popoverWindow: popoverWindow) {
                 return nil
             }
-
-            guard popoverWindow.attachedSheet == nil else { return event }
-            guard event.keyCode == RmbKeyCode.escape else { return event }
-
-            if remindersData.showingSearch {
-                remindersData.showingSearch = false
+            if handleEscapeKey(event, popoverWindow: popoverWindow) {
                 return nil
             }
-            if remindersData.showingRecentReminders {
-                remindersData.showingRecentReminders = false
-                return nil
-            }
-
-            AppDelegate.shared.popover.performClose(nil)
-            return nil
+            return event
         }
     }
 
+    private func activePopoverWindow(for event: NSEvent) -> NSWindow? {
+        let popover = AppDelegate.shared.popover
+        guard popover.isShown,
+              let window = popover.contentViewController?.view.window,
+              event.window === window else {
+            return nil
+        }
+        return window
+    }
+
+    private func handlePrintableKey(_ event: NSEvent, popoverWindow: NSWindow) -> Bool {
+        guard !remindersData.showingSearch,
+              !remindersData.availableCalendars.isEmpty,
+              popoverWindow.attachedSheet == nil || remindersData.pendingNewReminderTitle != nil,
+              let typedText = printableText(from: event) else {
+            return false
+        }
+        remindersData.pendingNewReminderTitle = (remindersData.pendingNewReminderTitle ?? "") + typedText
+        return true
+    }
+
+    private func handleEscapeKey(_ event: NSEvent, popoverWindow: NSWindow) -> Bool {
+        guard popoverWindow.attachedSheet == nil else { return false }
+        guard event.keyCode == RmbKeyCode.escape else { return false }
+
+        if remindersData.showingSearch {
+            remindersData.showingSearch = false
+            return true
+        }
+        if remindersData.showingRecentReminders {
+            remindersData.showingRecentReminders = false
+            return true
+        }
+
+        AppDelegate.shared.popover.performClose(nil)
+        return true
+    }
+
+    private static let nonPrintableCategories: Set<Unicode.GeneralCategory> = [
+        .control, .format, .surrogate, .privateUse, .unassigned
+    ]
+
     private func printableText(from event: NSEvent) -> String? {
-        let shortcutModifiers: NSEvent.ModifierFlags = [.command, .control]
-        guard event.modifierFlags.intersection(shortcutModifiers).isEmpty,
+        let nonTypingModifiers: NSEvent.ModifierFlags = [.command, .control]
+        guard event.modifierFlags.intersection(.deviceIndependentFlagsMask).isDisjoint(with: nonTypingModifiers),
               let characters = event.characters,
               !characters.isEmpty,
-              characters.unicodeScalars.allSatisfy(\.isPrintable) else {
+              characters.unicodeScalars.allSatisfy({
+                  !Self.nonPrintableCategories.contains($0.properties.generalCategory)
+              }) else {
             return nil
         }
 
@@ -181,17 +202,6 @@ struct ContentView: View {
     @ViewBuilder private var noFilterContent: some View {
         NoFilterSelectedView()
             .frame(maxHeight: .infinity)
-    }
-}
-
-private extension Unicode.Scalar {
-    var isPrintable: Bool {
-        switch properties.generalCategory {
-        case .control, .format, .surrogate, .privateUse, .unassigned:
-            return false
-        default:
-            return true
-        }
     }
 }
 

--- a/reminders-menubar/Views/ContentView.swift
+++ b/reminders-menubar/Views/ContentView.swift
@@ -67,11 +67,13 @@ struct ContentView: View {
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [remindersData] event in
             let popoverWindow = AppDelegate.shared.popover.contentViewController?.view.window
 
-            // When user types a printable character and no sheet/popover is open, open the create reminder sheet.
-            if !appHasPopoverOpen,
-               popoverWindow?.attachedSheet == nil,
-               !FilterPanelController.shared.isVisible,
-               let characters = event.charactersIgnoringModifiers,
+            // Let other UI layers (edit popovers, filter panel, sheets, alerts) handle their own keys
+            guard !appHasPopoverOpen else { return event }
+            guard !FilterPanelController.shared.isVisible else { return event }
+            guard popoverWindow?.attachedSheet == nil else { return event }
+
+            // When user types a printable character, open the create reminder sheet.
+            if let characters = event.charactersIgnoringModifiers,
                characters.count == 1,
                let scalar = characters.unicodeScalars.first,
                scalar.value >= 0x20, scalar.value <= 0x7E,
@@ -85,10 +87,6 @@ struct ContentView: View {
             }
 
             guard event.keyCode == RmbKeyCode.escape else { return event }
-            // Let other UI layers (edit popovers, filter panel, sheets, alerts) handle their own escape
-            guard !appHasPopoverOpen else { return event }
-            guard !FilterPanelController.shared.isVisible else { return event }
-            guard popoverWindow?.attachedSheet == nil else { return event }
 
             if remindersData.showingSearch {
                 remindersData.showingSearch = false

--- a/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
+++ b/reminders-menubar/Views/Helpers/RmbHighlightedTextField.swift
@@ -14,8 +14,6 @@ struct RmbHighlightedTextField: NSViewRepresentable {
     var allowNewLineAndTab: Bool
     var focusTrigger: Binding<UUID>?
 
-    private var lastFocusTrigger: UUID?
-
     private var textFont = NSFont.systemFont(ofSize: NSFont.systemFontSize)
     private var onSubmit: (() -> Void)?
     private var isInitialCharValidToAutoComplete: ((_ initialChar: String?) -> Bool)?
@@ -62,18 +60,27 @@ struct RmbHighlightedTextField: NSViewRepresentable {
             return
         }
 
-        if let trigger = focusTrigger?.wrappedValue,
-           trigger != context.coordinator.parent.lastFocusTrigger,
-           nsView.window?.firstResponder != textView {
-            context.coordinator.parent.lastFocusTrigger = trigger
-            nsView.window?.makeFirstResponder(textView)
-        }
+        context.coordinator.parent = self
 
         let selectedRange = textView.selectedRange()
-        textView.textStorage?.setAttributedString(getAttributedString(from: text.wrappedValue))
-        textView.setSelectedRange(selectedRange)
+        let updatedText = text.wrappedValue
+        let updatedTextLength = (updatedText as NSString).length
+        let selectionLocation = min(selectedRange.location, updatedTextLength)
+        let selectionLength = min(selectedRange.length, updatedTextLength - selectionLocation)
 
-        textView.scrollRangeToVisible(NSRange(location: text.wrappedValue.count, length: 0))
+        textView.textStorage?.setAttributedString(getAttributedString(from: updatedText))
+        textView.setSelectedRange(NSRange(location: selectionLocation, length: selectionLength))
+
+        if let trigger = focusTrigger?.wrappedValue,
+           trigger != context.coordinator.lastFocusTrigger {
+            context.coordinator.lastFocusTrigger = trigger
+            if nsView.window?.firstResponder != textView {
+                nsView.window?.makeFirstResponder(textView)
+            }
+            textView.setSelectedRange(NSRange(location: updatedTextLength, length: 0))
+        }
+
+        textView.scrollRangeToVisible(NSRange(location: updatedTextLength, length: 0))
 
         adjustDynamicHeight(for: textView, context: context)
     }
@@ -127,6 +134,7 @@ struct RmbHighlightedTextField: NSViewRepresentable {
 
         var isAutoCompleting = false
         var isDeletePressed = false
+        var lastFocusTrigger: UUID?
 
         init(_ parent: RmbHighlightedTextField) {
             self.parent = parent

--- a/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
+++ b/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
@@ -25,7 +25,6 @@ struct ReminderEditView: View {
     @State private var copyButtonIsHovered = false
     @State private var isCopied = false
     @State private var copiedDismissWork: DispatchWorkItem?
-    @State private var appliedInitialTitle: String
 
     private var reminderHasChildren: Bool {
         if case .edit(_, let hasChildren) = mode {
@@ -39,27 +38,21 @@ struct ReminderEditView: View {
         return reminder.attachedUrl != nil || reminder.mailUrl != nil
     }
 
-    let initialTitle: String
-
     init(isPresented: Binding<Bool>, reminder: EKReminder, reminderHasChildren: Bool) {
         self.mode = .edit(reminder, reminderHasChildren: reminderHasChildren)
-        self.initialTitle = ""
 
         _isPresented = isPresented
         _rmbReminder = State(initialValue: RmbReminder(reminder: reminder))
-        _appliedInitialTitle = State(initialValue: "")
     }
 
     init(isPresented: Binding<Bool>, initialTitle: String = "") {
         self.mode = .create
-        self.initialTitle = initialTitle
 
         var reminder = RmbReminder()
         reminder.title = initialTitle
 
         _isPresented = isPresented
         _rmbReminder = State(initialValue: reminder)
-        _appliedInitialTitle = State(initialValue: initialTitle)
     }
 
     var body: some View {
@@ -115,22 +108,11 @@ struct ReminderEditView: View {
                 if userPreferences.autoSuggestToday {
                     rmbReminder.setIsAutoSuggestingTodayForCreation()
                 }
+                consumePendingCreateReminderTyping()
             }
         }
-        .onChange(of: initialTitle) { newInitialTitle in
-            guard case .create = mode,
-                  newInitialTitle != appliedInitialTitle else {
-                return
-            }
-
-            var typedSuffix: Substring = ""
-            if rmbReminder.title.hasPrefix(appliedInitialTitle) {
-                typedSuffix = rmbReminder.title.dropFirst(appliedInitialTitle.count)
-            }
-
-            rmbReminder.title = newInitialTitle + typedSuffix
-            appliedInitialTitle = newInitialTitle
-            titleTextFieldFocusTrigger = UUID()
+        .onChange(of: remindersData.pendingCreateReminderTyping) { _ in
+            consumePendingCreateReminderTyping()
         }
     }
 
@@ -229,6 +211,17 @@ struct ReminderEditView: View {
                 )
             }
         }
+    }
+
+    private func consumePendingCreateReminderTyping() {
+        guard case .create = mode else { return }
+
+        let pendingTyping = remindersData.pendingCreateReminderTyping
+        guard !pendingTyping.isEmpty else { return }
+
+        rmbReminder.title += pendingTyping
+        remindersData.pendingCreateReminderTyping = ""
+        titleTextFieldFocusTrigger = UUID()
     }
 
     // MARK: - List

--- a/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
+++ b/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
@@ -123,7 +123,7 @@ struct ReminderEditView: View {
                 return
             }
 
-            let typedSuffix: Substring
+            let typedSuffix: Substring = ""
             if rmbReminder.title.hasPrefix(appliedInitialTitle) {
                 typedSuffix = rmbReminder.title.dropFirst(appliedInitialTitle.count)
             }

--- a/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
+++ b/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
@@ -45,14 +45,11 @@ struct ReminderEditView: View {
         _rmbReminder = State(initialValue: RmbReminder(reminder: reminder))
     }
 
-    init(isPresented: Binding<Bool>, initialTitle: String = "") {
+    init(isPresented: Binding<Bool>) {
         self.mode = .create
 
-        var reminder = RmbReminder()
-        reminder.title = initialTitle
-
         _isPresented = isPresented
-        _rmbReminder = State(initialValue: reminder)
+        _rmbReminder = State(initialValue: RmbReminder())
     }
 
     var body: some View {
@@ -108,11 +105,12 @@ struct ReminderEditView: View {
                 if userPreferences.autoSuggestToday {
                     rmbReminder.setIsAutoSuggestingTodayForCreation()
                 }
-                consumePendingCreateReminderTyping()
+                if let pendingTitle = remindersData.pendingNewReminderTitle, !pendingTitle.isEmpty {
+                    rmbReminder.title = pendingTitle
+                    titleTextFieldFocusTrigger = UUID()
+                }
+                remindersData.pendingNewReminderTitle = nil
             }
-        }
-        .onChange(of: remindersData.pendingCreateReminderTyping) { _ in
-            consumePendingCreateReminderTyping()
         }
     }
 
@@ -211,17 +209,6 @@ struct ReminderEditView: View {
                 )
             }
         }
-    }
-
-    private func consumePendingCreateReminderTyping() {
-        guard case .create = mode else { return }
-
-        let pendingTyping = remindersData.pendingCreateReminderTyping
-        guard !pendingTyping.isEmpty else { return }
-
-        rmbReminder.title += pendingTyping
-        remindersData.pendingCreateReminderTyping = ""
-        titleTextFieldFocusTrigger = UUID()
     }
 
     // MARK: - List

--- a/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
+++ b/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
@@ -123,7 +123,7 @@ struct ReminderEditView: View {
                 return
             }
 
-            var typedSuffix = Substring()
+            var typedSuffix: Substring = ""
             if rmbReminder.title.hasPrefix(appliedInitialTitle) {
                 typedSuffix = rmbReminder.title.dropFirst(appliedInitialTitle.count)
             }

--- a/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
+++ b/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
@@ -25,6 +25,7 @@ struct ReminderEditView: View {
     @State private var copyButtonIsHovered = false
     @State private var isCopied = false
     @State private var copiedDismissWork: DispatchWorkItem?
+    @State private var appliedInitialTitle: String
 
     private var reminderHasChildren: Bool {
         if case .edit(_, let hasChildren) = mode {
@@ -38,18 +39,27 @@ struct ReminderEditView: View {
         return reminder.attachedUrl != nil || reminder.mailUrl != nil
     }
 
+    let initialTitle: String
+
     init(isPresented: Binding<Bool>, reminder: EKReminder, reminderHasChildren: Bool) {
         self.mode = .edit(reminder, reminderHasChildren: reminderHasChildren)
+        self.initialTitle = ""
 
         _isPresented = isPresented
         _rmbReminder = State(initialValue: RmbReminder(reminder: reminder))
+        _appliedInitialTitle = State(initialValue: "")
     }
 
-    init(isPresented: Binding<Bool>) {
+    init(isPresented: Binding<Bool>, initialTitle: String = "") {
         self.mode = .create
+        self.initialTitle = initialTitle
+
+        var reminder = RmbReminder()
+        reminder.title = initialTitle
 
         _isPresented = isPresented
-        _rmbReminder = State(initialValue: RmbReminder())
+        _rmbReminder = State(initialValue: reminder)
+        _appliedInitialTitle = State(initialValue: initialTitle)
     }
 
     var body: some View {
@@ -106,6 +116,23 @@ struct ReminderEditView: View {
                     rmbReminder.setIsAutoSuggestingTodayForCreation()
                 }
             }
+        }
+        .onChange(of: initialTitle) { newInitialTitle in
+            guard case .create = mode,
+                  newInitialTitle != appliedInitialTitle else {
+                return
+            }
+
+            let typedSuffix: Substring
+            if rmbReminder.title.hasPrefix(appliedInitialTitle) {
+                typedSuffix = rmbReminder.title.dropFirst(appliedInitialTitle.count)
+            } else {
+                typedSuffix = ""
+            }
+
+            rmbReminder.title = newInitialTitle + typedSuffix
+            appliedInitialTitle = newInitialTitle
+            titleTextFieldFocusTrigger = UUID()
         }
     }
 

--- a/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
+++ b/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
@@ -123,7 +123,7 @@ struct ReminderEditView: View {
                 return
             }
 
-            let typedSuffix: Substring = ""
+            var typedSuffix = Substring()
             if rmbReminder.title.hasPrefix(appliedInitialTitle) {
                 typedSuffix = rmbReminder.title.dropFirst(appliedInitialTitle.count)
             }

--- a/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
+++ b/reminders-menubar/Views/ReminderEditView/ReminderEditView.swift
@@ -126,8 +126,6 @@ struct ReminderEditView: View {
             let typedSuffix: Substring
             if rmbReminder.title.hasPrefix(appliedInitialTitle) {
                 typedSuffix = rmbReminder.title.dropFirst(appliedInitialTitle.count)
-            } else {
-                typedSuffix = ""
             }
 
             rmbReminder.title = newInitialTitle + typedSuffix

--- a/reminders-menubar/Views/ToolbarView/CreateReminderButton.swift
+++ b/reminders-menubar/Views/ToolbarView/CreateReminderButton.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
 struct CreateReminderButton: View {
-    @EnvironmentObject var remindersData: RemindersData
-    @State private var showingCreateView = false
+    @Binding var showingCreateView: Bool
 
     var body: some View {
         Button {
@@ -21,15 +20,9 @@ struct CreateReminderButton: View {
         .keyboardShortcut("n", modifiers: .command)
         .modifier(ConfirmButtonModifier())
         .help(rmbLocalized(.newReminderButtonHelp))
-        .sheet(isPresented: $showingCreateView) {
-            ReminderEditView(isPresented: $showingCreateView)
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSPopover.didCloseNotification)) { _ in
-            showingCreateView = false
-        }
     }
 }
 
 #Preview {
-    CreateReminderButton()
+    CreateReminderButton(showingCreateView: .constant(false))
 }

--- a/reminders-menubar/Views/ToolbarView/CreateReminderButton.swift
+++ b/reminders-menubar/Views/ToolbarView/CreateReminderButton.swift
@@ -3,11 +3,9 @@ import SwiftUI
 struct CreateReminderButton: View {
     @EnvironmentObject var remindersData: RemindersData
     @State private var showingCreateView = false
-    @State private var pendingCreateTitle = ""
 
     var body: some View {
         Button {
-            remindersData.isOpeningCreateReminderSheet = true
             showingCreateView = true
         } label: {
             ToolbarButtonLabel {
@@ -31,27 +29,18 @@ struct CreateReminderButton: View {
         ) { _ in
             resetCreateReminderSheetState()
         }
-        .onReceive(remindersData.createReminderPublisher) { title in
-            if showingCreateView {
-                pendingCreateTitle += title
-            } else {
-                pendingCreateTitle = title
-                showingCreateView = true
-            }
+        .onChange(of: remindersData.pendingNewReminderTitle) { newValue in
+            guard newValue != nil, !showingCreateView else { return }
+            showingCreateView = true
         }
         .sheet(isPresented: $showingCreateView, onDismiss: resetCreateReminderSheetState) {
-            ReminderEditView(
-                isPresented: $showingCreateView,
-                initialTitle: pendingCreateTitle
-            )
+            ReminderEditView(isPresented: $showingCreateView)
         }
     }
 
     private func resetCreateReminderSheetState() {
         showingCreateView = false
-        pendingCreateTitle = ""
-        remindersData.isOpeningCreateReminderSheet = false
-        remindersData.pendingCreateReminderTyping = ""
+        remindersData.pendingNewReminderTitle = nil
     }
 }
 

--- a/reminders-menubar/Views/ToolbarView/CreateReminderButton.swift
+++ b/reminders-menubar/Views/ToolbarView/CreateReminderButton.swift
@@ -7,6 +7,7 @@ struct CreateReminderButton: View {
 
     var body: some View {
         Button {
+            remindersData.isOpeningCreateReminderSheet = true
             showingCreateView = true
         } label: {
             ToolbarButtonLabel {
@@ -28,8 +29,7 @@ struct CreateReminderButton: View {
                 object: AppDelegate.shared.popover
             )
         ) { _ in
-            showingCreateView = false
-            pendingCreateTitle = ""
+            resetCreateReminderSheetState()
         }
         .onReceive(remindersData.createReminderPublisher) { title in
             if showingCreateView {
@@ -39,14 +39,19 @@ struct CreateReminderButton: View {
                 showingCreateView = true
             }
         }
-        .sheet(isPresented: $showingCreateView, onDismiss: {
-            pendingCreateTitle = ""
-        }) {
+        .sheet(isPresented: $showingCreateView, onDismiss: resetCreateReminderSheetState) {
             ReminderEditView(
                 isPresented: $showingCreateView,
                 initialTitle: pendingCreateTitle
             )
         }
+    }
+
+    private func resetCreateReminderSheetState() {
+        showingCreateView = false
+        pendingCreateTitle = ""
+        remindersData.isOpeningCreateReminderSheet = false
+        remindersData.pendingCreateReminderTyping = ""
     }
 }
 

--- a/reminders-menubar/Views/ToolbarView/CreateReminderButton.swift
+++ b/reminders-menubar/Views/ToolbarView/CreateReminderButton.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 
 struct CreateReminderButton: View {
-    @Binding var showingCreateView: Bool
+    @EnvironmentObject var remindersData: RemindersData
+    @State private var showingCreateView = false
+    @State private var pendingCreateTitle = ""
 
     var body: some View {
         Button {
@@ -20,9 +22,35 @@ struct CreateReminderButton: View {
         .keyboardShortcut("n", modifiers: .command)
         .modifier(ConfirmButtonModifier())
         .help(rmbLocalized(.newReminderButtonHelp))
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: NSPopover.didCloseNotification,
+                object: AppDelegate.shared.popover
+            )
+        ) { _ in
+            showingCreateView = false
+            pendingCreateTitle = ""
+        }
+        .onReceive(remindersData.createReminderPublisher) { title in
+            if showingCreateView {
+                pendingCreateTitle += title
+            } else {
+                pendingCreateTitle = title
+                showingCreateView = true
+            }
+        }
+        .sheet(isPresented: $showingCreateView, onDismiss: {
+            pendingCreateTitle = ""
+        }) {
+            ReminderEditView(
+                isPresented: $showingCreateView,
+                initialTitle: pendingCreateTitle
+            )
+        }
     }
 }
 
 #Preview {
-    CreateReminderButton(showingCreateView: .constant(false))
+    CreateReminderButton()
+        .environmentObject(RemindersData())
 }

--- a/reminders-menubar/Views/ToolbarView/ToolbarView.swift
+++ b/reminders-menubar/Views/ToolbarView/ToolbarView.swift
@@ -2,11 +2,10 @@ import SwiftUI
 
 struct ToolbarView: View {
     @EnvironmentObject var remindersData: RemindersData
-    @Binding var showingCreateView: Bool
 
     var body: some View {
         HStack(spacing: 4) {
-            CreateReminderButton(showingCreateView: $showingCreateView)
+            CreateReminderButton()
                 .disabled(remindersData.availableCalendars.isEmpty)
 
             Spacer()
@@ -32,6 +31,6 @@ struct ToolbarView: View {
 }
 
 #Preview {
-    ToolbarView(showingCreateView: .constant(false))
+    ToolbarView()
         .environmentObject(RemindersData())
 }

--- a/reminders-menubar/Views/ToolbarView/ToolbarView.swift
+++ b/reminders-menubar/Views/ToolbarView/ToolbarView.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 struct ToolbarView: View {
     @EnvironmentObject var remindersData: RemindersData
+    @Binding var showingCreateView: Bool
 
     var body: some View {
         HStack(spacing: 4) {
-            CreateReminderButton()
+            CreateReminderButton(showingCreateView: $showingCreateView)
                 .disabled(remindersData.availableCalendars.isEmpty)
 
             Spacer()
@@ -31,6 +32,6 @@ struct ToolbarView: View {
 }
 
 #Preview {
-    ToolbarView()
+    ToolbarView(showingCreateView: .constant(false))
         .environmentObject(RemindersData())
 }


### PR DESCRIPTION
## Summary

  This PR adds a faster reminder creation flow. When the main popover is open, typing a printable character immediately opens the new reminder form and uses
  that character as the beginning of the title.

  ## Changes

  - Captures printable keyboard input from the main popover.
  - Opens the reminder creation sheet automatically.
  - Preserves characters typed while the sheet is opening.
  - Places the cursor after the captured text so typing continues in the correct order.
  - Centralizes the creation sheet state in ContentView.
  - Improves text field focus and cursor handling, including Unicode text lengths.