### PR TITLE
Add optional floating reminders window

### DIFF
--- a/reminders-menubar/AppCommands.swift
+++ b/reminders-menubar/AppCommands.swift
@@ -2,6 +2,22 @@ import SwiftUI
 
 struct AppCommands: Commands {
     @CommandsBuilder var body: some Commands {
+        CommandMenu(Text(verbatim: "Window")) {
+            Button {
+                AppDelegate.shared.showRemindersWindow()
+            } label: {
+                Text(rmbLocalized(.openRemindersWindowButton))
+            }
+            .keyboardShortcut(KeyEquivalent("0"), modifiers: [.command, .option])
+
+            Button {
+                AppDelegate.shared.toggleRemindersWindowFloating()
+            } label: {
+                Text(rmbLocalized(.keepRemindersWindowFloatingButton))
+            }
+            .keyboardShortcut(KeyEquivalent("f"), modifiers: [.command, .option])
+        }
+
         CommandMenu(Text(verbatim: "Edit")) {
             // NOTE: macOS 13.0 already has the below shortcuts for TextField.
             // Shortcuts only need to be registered for versions earlier than macOS 13.0.

--- a/reminders-menubar/AppDelegate.swift
+++ b/reminders-menubar/AppDelegate.swift
@@ -42,16 +42,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var currentReminderPreview: String?
 
     let popover = NSPopover()
+    private(set) var remindersWindow: NSWindow?
     lazy var statusBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    private var remindersWindowCloseCancellationToken: AnyCancellable?
+    private var remindersWindowRemindersData: RemindersData?
+    private var remindersWindowCopyShortcutCoordinator: CopyShortcutCoordinator?
     
     var contentViewController: NSViewController {
-        let contentView = ContentView()
         let remindersData = RemindersData()
         let copyShortcutCoordinator = CopyShortcutCoordinator()
-        return NSHostingController(
-            rootView: contentView
-                .environmentObject(remindersData)
-                .environmentObject(copyShortcutCoordinator)
+        return makeContentViewController(
+            presentationStyle: .popover,
+            remindersData: remindersData,
+            copyShortcutCoordinator: copyShortcutCoordinator
         )
     }
 
@@ -165,6 +168,107 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.activate(ignoringOtherApps: true)
             popover.contentViewController?.view.window?.makeKey()
         }
+    }
+
+    func showRemindersWindow() {
+        guard RemindersService.shared.isAuthorized else {
+            requestAuthorization()
+            return
+        }
+
+        popover.performClose(nil)
+
+        if let remindersWindow {
+            NSApp.activate(ignoringOtherApps: true)
+            remindersWindow.makeKeyAndOrderFront(nil)
+            remindersWindow.orderFrontRegardless()
+            return
+        }
+
+        let remindersData = RemindersData()
+        let copyShortcutCoordinator = CopyShortcutCoordinator()
+        let contentViewController = makeContentViewController(
+            presentationStyle: .window,
+            remindersData: remindersData,
+            copyShortcutCoordinator: copyShortcutCoordinator
+        )
+        remindersWindowRemindersData = remindersData
+        remindersWindowCopyShortcutCoordinator = copyShortcutCoordinator
+
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: MainPopoverSizing.defaultSize),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = AppConstants.appName
+        window.contentViewController = contentViewController
+        window.minSize = MainPopoverSizing.minSize
+        window.maxSize = MainPopoverSizing.maxSize
+        window.isReleasedWhenClosed = false
+        let frameAutosaveName = "RemindersMenuBarWindow"
+        if !window.setFrameUsingName(frameAutosaveName) {
+            window.center()
+        }
+        window.setFrameAutosaveName(frameAutosaveName)
+
+        remindersWindow = window
+        applyRemindersWindowFloatingPreference()
+        observeRemindersWindowClose(window)
+
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
+    }
+
+    func closeRemindersWindow() {
+        remindersWindow?.performClose(nil)
+    }
+
+    func toggleRemindersWindowFloating() {
+        UserPreferences.shared.remindersWindowFloatsOnTop.toggle()
+        applyRemindersWindowFloatingPreference()
+    }
+
+    private func makeContentViewController(
+        presentationStyle: ContentPresentationStyle,
+        remindersData: RemindersData,
+        copyShortcutCoordinator: CopyShortcutCoordinator
+    ) -> NSViewController {
+        let contentView = ContentView(presentationStyle: presentationStyle)
+        return NSHostingController(
+            rootView: contentView
+                .environmentObject(remindersData)
+                .environmentObject(copyShortcutCoordinator)
+        )
+    }
+
+    private func applyRemindersWindowFloatingPreference() {
+        guard let remindersWindow else { return }
+
+        if UserPreferences.shared.remindersWindowFloatsOnTop {
+            remindersWindow.level = .floating
+            remindersWindow.collectionBehavior = [
+                .canJoinAllSpaces,
+                .fullScreenAuxiliary,
+                .managed
+            ]
+        } else {
+            remindersWindow.level = .normal
+            remindersWindow.collectionBehavior = [.managed]
+        }
+    }
+
+    private func observeRemindersWindowClose(_ window: NSWindow) {
+        remindersWindowCloseCancellationToken = NotificationCenter.default
+            .publisher(for: NSWindow.willCloseNotification, object: window)
+            .first()
+            .sink { [weak self] _ in
+                self?.remindersWindow = nil
+                self?.remindersWindowRemindersData = nil
+                self?.remindersWindowCopyShortcutCoordinator = nil
+                self?.remindersWindowCloseCancellationToken = nil
+            }
     }
 
     // - MARK: Popover sizing

--- a/reminders-menubar/Resources/Localizable.xcstrings
+++ b/reminders-menubar/Resources/Localizable.xcstrings
@@ -14154,6 +14154,52 @@
         }
       }
     },
+    "keepRemindersWindowFloatingButton" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep Window Floating"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "窗口保持悬浮"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視窗保持浮動"
+          }
+        }
+      }
+    },
+    "openRemindersWindowButton" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Window"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打開視窗"
+          }
+        }
+      }
+    },
     "reloadRemindersDataButton" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/reminders-menubar/Resources/remindersLocalized.swift
+++ b/reminders-menubar/Resources/remindersLocalized.swift
@@ -59,6 +59,8 @@ enum RemindersMenuBarLocalizedKeys: String {
     case showMenuBarTodayCountOption
     case showMenuBarAllRemindersCountOption
     case showMenuBarNoCountOption
+    case openRemindersWindowButton
+    case keepRemindersWindowFloatingButton
     case reloadRemindersDataButton
     case appAboutButton
     case appQuitButton

--- a/reminders-menubar/Services/RightClickMenuHelper.swift
+++ b/reminders-menubar/Services/RightClickMenuHelper.swift
@@ -22,6 +22,21 @@ final class RightClickMenuHelper: NSObject {
         menu.addItem(.separator())
 
         menu.addItem(makeMenuItem(
+            title: rmbLocalized(.openRemindersWindowButton),
+            action: #selector(openRemindersWindow),
+            systemSymbolName: "macwindow"
+        ))
+
+        menu.addItem(makeMenuItem(
+            title: rmbLocalized(.keepRemindersWindowFloatingButton),
+            action: #selector(toggleRemindersWindowFloating),
+            systemSymbolName: "pin",
+            state: UserPreferences.shared.remindersWindowFloatsOnTop ? .on : .off
+        ))
+
+        menu.addItem(.separator())
+
+        menu.addItem(makeMenuItem(
             title: rmbLocalized(.reloadRemindersDataButton),
             action: #selector(reloadData),
             systemSymbolName: "arrow.clockwise"
@@ -91,6 +106,14 @@ final class RightClickMenuHelper: NSObject {
 
     @objc private func reloadData() {
         NotificationCenter.default.post(name: .remindersDataShouldUpdate, object: nil)
+    }
+
+    @objc private func openRemindersWindow() {
+        AppDelegate.shared.showRemindersWindow()
+    }
+
+    @objc private func toggleRemindersWindowFloating() {
+        AppDelegate.shared.toggleRemindersWindowFloating()
     }
 
     @objc private func openSettingsAction() {

--- a/reminders-menubar/Services/UserPreferences.swift
+++ b/reminders-menubar/Services/UserPreferences.swift
@@ -33,6 +33,7 @@ private enum PreferencesKeys {
     static let showTagsBeforeCalendars = "showTagsBeforeCalendars"
     static let filterTagRemindersByCalendar = "filterTagRemindersByCalendar"
     static let completionAnimationEnabled = "completionAnimationEnabled"
+    static let remindersWindowFloatsOnTop = "remindersWindowFloatsOnTop"
 }
 
 // TODO: Resolve body length of UserPreferences
@@ -198,6 +199,17 @@ class UserPreferences: ObservableObject {
     }() {
         didSet {
             UserPreferences.defaults.set(completionAnimationEnabled, forKey: PreferencesKeys.completionAnimationEnabled)
+        }
+    }
+
+    @Published var remindersWindowFloatsOnTop: Bool = {
+        return defaults.bool(forKey: PreferencesKeys.remindersWindowFloatsOnTop)
+    }() {
+        didSet {
+            UserPreferences.defaults.set(
+                remindersWindowFloatsOnTop,
+                forKey: PreferencesKeys.remindersWindowFloatsOnTop
+            )
         }
     }
     

--- a/reminders-menubar/Views/ContentView.swift
+++ b/reminders-menubar/Views/ContentView.swift
@@ -1,11 +1,22 @@
 import SwiftUI
 import EventKit
 
+enum ContentPresentationStyle {
+    case popover
+    case window
+}
+
 struct ContentView: View {
+    let presentationStyle: ContentPresentationStyle
+
     @EnvironmentObject var remindersData: RemindersData
     @ObservedObject var userPreferences = UserPreferences.shared
     @State private var appHasPopoverOpen = false
     @State private var keyMonitor: Any?
+
+    init(presentationStyle: ContentPresentationStyle = .popover) {
+        self.presentationStyle = presentationStyle
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -23,7 +34,7 @@ struct ContentView: View {
                 noFilterContent
             }
         }
-        .overlay(PopoverResizeHandleView().padding(4), alignment: .bottomTrailing)
+        .overlay(resizeHandleOverlay, alignment: .bottomTrailing)
         .modifier(RmbBackgroundModifier())
         .preferredColorScheme(userPreferences.rmbColorScheme.colorScheme)
         .environment(\.appHasPopoverOpen, $appHasPopoverOpen)
@@ -35,6 +46,7 @@ struct ContentView: View {
                 object: AppDelegate.shared.popover
             )
         ) { _ in
+            guard presentationStyle == .popover else { return }
             remindersData.showingSearch = false
             remindersData.showingRecentReminders = false
         }
@@ -42,37 +54,52 @@ struct ContentView: View {
 
     // MARK: - Key handling
 
+    @ViewBuilder private var resizeHandleOverlay: some View {
+        if presentationStyle == .popover {
+            PopoverResizeHandleView().padding(4)
+        }
+    }
+
     private func startKeyMonitor() {
         guard keyMonitor == nil else { return }
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard let popoverWindow = activePopoverWindow(for: event) else { return event }
+            guard let activeWindow = activePresentationWindow(for: event) else { return event }
             guard !appHasPopoverOpen else { return event }
             guard !FilterPanelController.shared.isVisible else { return event }
 
-            if handlePrintableKey(event, popoverWindow: popoverWindow) {
+            if handlePrintableKey(event, activeWindow: activeWindow) {
                 return nil
             }
-            if handleEscapeKey(event, popoverWindow: popoverWindow) {
+            if handleEscapeKey(event, activeWindow: activeWindow) {
                 return nil
             }
             return event
         }
     }
 
-    private func activePopoverWindow(for event: NSEvent) -> NSWindow? {
-        let popover = AppDelegate.shared.popover
-        guard popover.isShown,
-              let window = popover.contentViewController?.view.window,
-              event.window === window else {
-            return nil
+    private func activePresentationWindow(for event: NSEvent) -> NSWindow? {
+        switch presentationStyle {
+        case .popover:
+            let popover = AppDelegate.shared.popover
+            guard popover.isShown,
+                  let window = popover.contentViewController?.view.window,
+                  event.window === window else {
+                return nil
+            }
+            return window
+        case .window:
+            guard let window = AppDelegate.shared.remindersWindow,
+                  event.window === window else {
+                return nil
+            }
+            return window
         }
-        return window
     }
 
-    private func handlePrintableKey(_ event: NSEvent, popoverWindow: NSWindow) -> Bool {
+    private func handlePrintableKey(_ event: NSEvent, activeWindow: NSWindow) -> Bool {
         guard !remindersData.showingSearch,
               !remindersData.availableCalendars.isEmpty,
-              popoverWindow.attachedSheet == nil || remindersData.pendingNewReminderTitle != nil,
+              activeWindow.attachedSheet == nil || remindersData.pendingNewReminderTitle != nil,
               let typedText = printableText(from: event) else {
             return false
         }
@@ -80,8 +107,8 @@ struct ContentView: View {
         return true
     }
 
-    private func handleEscapeKey(_ event: NSEvent, popoverWindow: NSWindow) -> Bool {
-        guard popoverWindow.attachedSheet == nil else { return false }
+    private func handleEscapeKey(_ event: NSEvent, activeWindow: NSWindow) -> Bool {
+        guard activeWindow.attachedSheet == nil else { return false }
         guard event.keyCode == RmbKeyCode.escape else { return false }
 
         if remindersData.showingSearch {
@@ -93,7 +120,12 @@ struct ContentView: View {
             return true
         }
 
-        AppDelegate.shared.popover.performClose(nil)
+        switch presentationStyle {
+        case .popover:
+            AppDelegate.shared.popover.performClose(nil)
+        case .window:
+            AppDelegate.shared.closeRemindersWindow()
+        }
         return true
     }
 
@@ -233,6 +265,6 @@ struct ListSectionModifier: ViewModifier {
 }
 
 #Preview {
-    ContentView()
+    ContentView(presentationStyle: .window)
         .environmentObject(RemindersData())
 }


### PR DESCRIPTION
## Summary
- Add an optional standalone reminders window alongside the existing menu bar popover.
- Add menu entries to open the reminders window and keep it floating above other windows.
- Reuse the existing ContentView while preserving popover-specific resize and close behavior.
- Persist the floating window preference and add localized strings for the new menu items.

## Validation
- xcodebuild -project reminders-menubar.xcodeproj -scheme "Reminders MenuBar" -configuration Release -derivedDataPath /tmp/reminders-menubar-prcheck CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=- build
- /Applications/Xcode.app/Contents/Developer/usr/bin/xcstringstool compile --dry-run --output-directory /tmp/reminders-xcstrings-prcheck reminders-menubar/Resources/Localizable.xcstrings
- git diff --check

Note: SwiftLint runs during xcodebuild and reports existing repository warnings; this PR adds one additional warning by extending RightClickMenuHelper.buildRightClickMenu.